### PR TITLE
Real stream passive receive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           cmake-version: '3.16.9'
       - name: release build with debug log off
-        run: CMAKE_BUILD_TYPE=Release QUIC_ENABLE_LOGGING=OFF make ci
+        run: make ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
           cp ./rebar3 /usr/local/bin/rebar3
       - name: release build
         run: |
+          export PATH="/usr/local/opt/erlang@23/bin:$PATH"
           make ci
 
   linux:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ accept_stream(Connection, Opts, Timeout) ->
   {ok, Stream} | {error, any()} | {error, any(), ErrorCode::integer()}.
 ```
 
-
 Accept stream on a existing connection. 
 
 This is a blocking call.
@@ -271,5 +270,4 @@ Returns connection local IP and Port.
 
 # License
 Apache License Version 2.0
-
 

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -79,6 +79,8 @@ init_s_ctx()
   s_ctx->closed = false;
   s_ctx->passive_recv_bytes = 0;
   s_ctx->Buffer = NULL;
+  s_ctx->BufferLen = 0;
+  s_ctx->BufferOffset = 0;
   return s_ctx;
 }
 

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -77,6 +77,8 @@ init_s_ctx()
   s_ctx->env = enif_alloc_env();
   s_ctx->lock = enif_mutex_create("quicer:s_ctx");
   s_ctx->closed = false;
+  s_ctx->passive_recv_bytes = 0;
+  s_ctx->Buffer = NULL;
   return s_ctx;
 }
 

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -57,7 +57,7 @@ typedef struct
   size_t BufferLen;
   size_t BufferOffset;
   BOOLEAN is_wait_for_data;
-  uint64_t passive_recv_bytes;
+  uint64_t passive_recv_bytes; // 0 means size unspecified
 } QuicerStreamCTX;
 
 QuicerListenerCTX *init_l_ctx();

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -54,8 +54,8 @@ typedef struct
   ErlNifMutex *lock;
   BOOLEAN closed;
   uint8_t *Buffer;
-  size_t BufferLen;
-  size_t BufferOffset;
+  uint64_t BufferLen;
+  uint64_t BufferOffset;
   BOOLEAN is_wait_for_data;
   uint64_t passive_recv_bytes; // 0 means size unspecified
 } QuicerStreamCTX;

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -55,6 +55,7 @@ typedef struct
   BOOLEAN closed;
   uint8_t *Buffer;
   size_t BufferLen;
+  size_t BufferOffset;
   BOOLEAN is_wait_for_data;
   uint64_t passive_recv_bytes;
 } QuicerStreamCTX;

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -53,6 +53,10 @@ typedef struct
   ErlNifEnv *env; //@todo destruct env
   ErlNifMutex *lock;
   BOOLEAN closed;
+  uint8_t *Buffer;
+  size_t BufferLen;
+  BOOLEAN is_wait_for_data;
+  uint64_t passive_recv_bytes;
 } QuicerStreamCTX;
 
 QuicerListenerCTX *init_l_ctx();

--- a/c_src/quicer_eterms.h
+++ b/c_src/quicer_eterms.h
@@ -204,10 +204,20 @@ extern ERL_NIF_TERM ATOM_QUIC_SETTINGS_DesiredVersionsListLength;
 /*----------------------------------------------------------*/
 /* QUIC_SETTINGS ends                                       */
 /*----------------------------------------------------------*/
+
+/*----------------------------------------------------------*/
+/* QUIC_STREAM_OPTS starts                                  */
+/*----------------------------------------------------------*/
+extern ERL_NIF_TERM ATOM_QUIC_STREAM_OPTS_ACTIVE;
+/*----------------------------------------------------------*/
+/* QUIC_STREAM_OPTS ends                                    */
+/*----------------------------------------------------------*/
+
 extern ERL_NIF_TERM ATOM_CLOSED;
 extern ERL_NIF_TERM ATOM_SHUTDOWN;
 extern ERL_NIF_TERM ATOM_PEER_SEND_SHUTDOWN;
 extern ERL_NIF_TERM ATOM_PEER_SEND_ABORTED;
+extern ERL_NIF_TERM ATOM_EINVAL;
 extern ERL_NIF_TERM ATOM_QUIC;
 /*----------------------------------------------------------*/
 /* ATOMS ends here                                          */

--- a/c_src/quicer_listener.c
+++ b/c_src/quicer_listener.c
@@ -61,8 +61,9 @@ ServerListenerCallback(__unused_parm__ HQUIC Listener,
                                  c_ctx);
       // @todo error handling here.
       Status = MsQuic->ConnectionSetConfiguration(
-         //@todo maybe use c_ctx->Configuration? or it should have a copy?
-          Event->NEW_CONNECTION.Connection, l_ctx->Configuration);
+          //@todo maybe use c_ctx->Configuration? or it should have a copy?
+          Event->NEW_CONNECTION.Connection,
+          l_ctx->Configuration);
       break;
     default:
       break;

--- a/c_src/quicer_listener.c
+++ b/c_src/quicer_listener.c
@@ -61,6 +61,7 @@ ServerListenerCallback(__unused_parm__ HQUIC Listener,
                                  c_ctx);
       // @todo error handling here.
       Status = MsQuic->ConnectionSetConfiguration(
+         //@todo maybe use c_ctx->Configuration? or it should have a copy?
           Event->NEW_CONNECTION.Connection, l_ctx->Configuration);
       break;
     default:

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -211,10 +211,19 @@ ERL_NIF_TERM ATOM_QUIC_SETTINGS_DesiredVersionsListLength;
 /* QUIC_SETTINGS ends      */
 /*----------------------------------------------------------*/
 
+/*----------------------------------------------------------*/
+/* QUIC_STREAM_OPTS starts */
+/*----------------------------------------------------------*/
+ERL_NIF_TERM ATOM_QUIC_STREAM_OPTS_ACTIVE;
+/*----------------------------------------------------------*/
+/* QUIC_STREAM_OPTS ends  */
+/*----------------------------------------------------------*/
+
 ERL_NIF_TERM ATOM_CLOSED;
 ERL_NIF_TERM ATOM_SHUTDOWN;
 ERL_NIF_TERM ATOM_PEER_SEND_SHUTDOWN;
 ERL_NIF_TERM ATOM_PEER_SEND_ABORTED;
+ERL_NIF_TERM ATOM_EINVAL;
 ERL_NIF_TERM ATOM_QUIC;
 
 // Mirror 'status' in msquic_linux.h
@@ -406,6 +415,9 @@ ERL_NIF_TERM ATOM_QUIC;
   ATOM(ATOM_QUIC_SETTINGS_DesiredVersionsListLength,                          \
        desired_versions_list_length);                                         \
   /*                  QUIC_SETTINGS end                        */             \
+  /*                  QUIC_STREAM_OPTS start                        */        \
+  ATOM(ATOM_QUIC_STREAM_OPTS_ACTIVE, active)                                  \
+  /*                  QUIC_STREAM_OPTS end                        */          \
   ATOM(ATOM_CERT, cert);                                                      \
   ATOM(ATOM_KEY, key);                                                        \
   ATOM(ATOM_ALPN, alpn);                                                      \
@@ -413,6 +425,7 @@ ERL_NIF_TERM ATOM_QUIC;
   ATOM(ATOM_SHUTDOWN, shutdown);                                              \
   ATOM(ATOM_PEER_SEND_SHUTDOWN, peer_send_shutdown);                          \
   ATOM(ATOM_PEER_SEND_ABORTED, peer_send_aborted);                            \
+  ATOM(ATOM_EINVAL, einval);                                                  \
   ATOM(ATOM_QUIC, quic);
 
 HQUIC Registration;
@@ -793,6 +806,7 @@ static ErlNifFunc nif_funcs[] = {
   { "async_accept_stream", 2, async_accept_stream2, 0},
   { "start_stream", 2, async_start_stream2, 0},
   { "send", 2, send2, 0},
+  { "recv", 2, recv2, 0},
   { "close_stream", 1, close_stream1, 0},
   { "sockname", 1, sockname1, 0},
   { "getopt", 3, getopt3, 0},

--- a/c_src/quicer_queue.h
+++ b/c_src/quicer_queue.h
@@ -39,6 +39,7 @@ typedef struct ACCEPTOR
 {
   CXPLAT_LIST_ENTRY Link;
   ErlNifPid Pid;
+  BOOLEAN active; // is active receiver?
 } ACCEPTOR;
 
 typedef struct AcceptorsQueue

--- a/c_src/quicer_stream.c
+++ b/c_src/quicer_stream.c
@@ -296,6 +296,7 @@ async_start_stream2(ErlNifEnv *env,
   // the stream being started until data is sent on the stream.
   //
   if (QUIC_FAILED(Status = MsQuic->StreamStart(s_ctx->Stream,
+                                               // @todo flag in options
                                                QUIC_STREAM_START_FLAG_NONE)))
     {
       // note, stream call back would close the stream.

--- a/c_src/quicer_stream.h
+++ b/c_src/quicer_stream.h
@@ -28,7 +28,10 @@ async_accept_stream2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM
 async_start_stream2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
 ERL_NIF_TERM send2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM
 close_stream1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -108,7 +108,7 @@ accept(LSock, Opts, Timeout) ->
 close_connection(Conn) ->
   quicer_nif:close_connection(Conn).
 
--spec accept_stream(connection_handler(), proplists:proplist()) ->
+-spec accept_stream(connection_handler(), proplists:proplist() | map()) ->
         {ok, stream_handler()} | {error, any()}.
 accept_stream(Conn, Opts) ->
   accept_stream(Conn, Opts, infinity).
@@ -129,14 +129,14 @@ accept_stream(Conn, Opts, Timeout) when is_map(Opts) ->
       E
   end.
 
--spec async_accept_stream(connection_handler(), proplists:proplist() | map) ->
+-spec async_accept_stream(connection_handler(), proplists:proplist() | map()) ->
         {ok, connection_handler()} | {error, any()}.
 async_accept_stream(Conn, Opts) when is_list(Opts)->
-  accept_stream(Conn, maps:from_list(Opts));
+  async_accept_stream(Conn, maps:from_list(Opts));
 async_accept_stream(Conn, Opts) when is_map(Opts) ->
   quicer_nif:async_accept_stream(Conn, maps:merge(default_stream_opts(), Opts)).
 
--spec start_stream(connection_handler(), proplists:proplists() | map) ->
+-spec start_stream(connection_handler(), proplists:proplists() | map()) ->
         {ok, stream_handler()} | {error, any()}.
 start_stream(Conn, Opts) when is_list(Opts)->
   start_stream(Conn, maps:from_list(Opts));

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -26,6 +26,7 @@
         , async_accept_stream/2
         , start_stream/2
         , send/2
+        , recv/2
         , close_stream/1
         , sockname/1
         , getopt/3
@@ -91,6 +92,9 @@ start_stream(_Conn, _Opts) ->
   erlang:nif_error(nif_library_not_loaded).
 
 send(_Stream, _Data) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+recv(_Stream, _Len) ->
   erlang:nif_error(nif_library_not_loaded).
 
 close_stream(_Stream) ->

--- a/src/quicer_stream.erl
+++ b/src/quicer_stream.erl
@@ -69,7 +69,7 @@ init([Conn, SOpts]) when is_list(SOpts) ->
     init([Conn, maps:from_list(SOpts)]);
 init([Conn, SOpts]) ->
     process_flag(trap_exit, true),
-    {ok, Conn} = quicer_nif:async_accept_stream(Conn, SOpts),
+    {ok, Conn} = quicer:async_accept_stream(Conn, SOpts),
     {ok, #state{opts = SOpts}}.
 
 %%--------------------------------------------------------------------

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -674,14 +674,16 @@ default_listen_opts(Config) ->
 
 wait_for_close(Stm) ->
   receive
-    {quic, closed, Stm, _} ->
-      receive {quic, closed, _Conn} -> ok
-      after 2000 ->
-          receive Any ->
-              ct:fail({unexpected_recv, Any})
-          after 0 ->
-              wait_for_close(Stm)
-          end
+    {quic, closed, Stm, _} -> ok;
+    {quic, peer_send_aborted, Stm, _ErrorNo} -> ok
+  end,
+  receive
+    {quic, closed, _Conn} -> ok
+  after 3000 ->
+      receive Any ->
+          ct:fail({unexpected_recv, Any})
+      after 0 ->
+          wait_for_close(Stm)
       end
   end.
 

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -517,7 +517,7 @@ tc_setopt(Config) ->
       {ok, Conn} = quicer:connect("localhost", Port, Opts, 5000),
       {ok, Stm0} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm0, <<"ping">>),
-      {ok, Stm1} = quicer:start_stream(Conn, []),
+      {ok, Stm1} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm1, <<"ping">>),
       {P, _} = spawn_monitor(fun () -> Owner ! quicer:recv(Stm1, 4) end),
       receive
@@ -548,7 +548,7 @@ tc_app_echo_server(Config) ->
   Options = {ListenerOpts, ConnectionOpts, StreamOpts},
   {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
   {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
-  {ok, Stm} = quicer:start_stream(Conn, []),
+  {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
   {ok, 4} = quicer:send(Stm, <<"ping">>),
   {ok, 4} = quicer:send(Stm, <<"ping">>),
   {ok, 4} = quicer:send(Stm, <<"ping">>),

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -190,12 +190,13 @@ tc_conn_basic(Config)->
 tc_conn_other_port(Config)->
   Port = 4568,
   Owner = self(),
-  {SPid, _Ref} = spawn_monitor(fun() -> simple_conn_server(Owner, Config, Port) end),
+  {SPid, Ref} = spawn_monitor(fun() -> simple_conn_server(Owner, Config, Port) end),
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
       ok = quicer:close_connection(Conn),
-      SPid ! done
+      SPid ! done,
+      ok = ensure_server_exit_normal(Ref)
   after 1000 ->
       ct:fail("timeout")
   end.
@@ -203,7 +204,7 @@ tc_conn_other_port(Config)->
 tc_stream_client_init(Config) ->
   Port = 4568,
   Owner = self(),
-  {SPid, _Ref} = spawn_monitor(fun() -> simple_stream_server(Owner, Config, Port) end),
+  {SPid, Ref} = spawn_monitor(fun() -> simple_stream_server(Owner, Config, Port) end),
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
@@ -211,7 +212,8 @@ tc_stream_client_init(Config) ->
       {ok, {_, _}} = quicer:sockname(Stm),
       ok = quicer:close_stream(Stm),
       wait_for_close(Stm),
-      SPid ! done
+      SPid ! done,
+      ok = ensure_server_exit_normal(Ref)
   after 1000 ->
       ct:fail("timeout")
   end.
@@ -219,7 +221,7 @@ tc_stream_client_init(Config) ->
 tc_stream_client_send(Config) ->
   Port = 4569,
   Owner = self(),
-  {SPid, _Ref} = spawn_monitor(fun() -> ping_pong_server(Owner, Config, Port) end),
+  {SPid, Ref} = spawn_monitor(fun() -> ping_pong_server(Owner, Config, Port) end),
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
@@ -233,7 +235,8 @@ tc_stream_client_send(Config) ->
           ct:fail("Unexpected Msg ~p", [Other])
       end,
       wait_for_close(Stm),
-      SPid ! done
+      SPid ! done,
+      ok = ensure_server_exit_normal(Ref)
   after 1000 ->
       ct:fail("timeout")
   end.
@@ -245,7 +248,7 @@ tc_stream_passive_receive(Config) ->
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
-      {ok, Stm} = quicer:start_stream(Conn, []),
+      {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
       {ok, <<"pong">>} = quicer:recv(Stm, 0),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
@@ -263,7 +266,7 @@ tc_stream_passive_receive_buffer(Config) ->
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
-      {ok, Stm} = quicer:start_stream(Conn, []),
+      {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
       {ok, <<"pong">>} = quicer:recv(Stm, 0),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
@@ -284,7 +287,7 @@ tc_stream_passive_receive_large_buffer_1(Config) ->
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
-      {ok, Stm} = quicer:start_stream(Conn, []),
+      {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
@@ -302,7 +305,7 @@ tc_stream_passive_receive_large_buffer_2(Config) ->
   receive
     listener_ready ->
       {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
-      {ok, Stm} = quicer:start_stream(Conn, []),
+      {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
       timer:sleep(100),
       {ok, 4} = quicer:send(Stm, <<"ping">>),
@@ -496,9 +499,9 @@ tc_idle_timeout(Config) ->
   {SPid, _Ref} = spawn_monitor(fun() -> echo_server(Owner, Config, Port) end),
   receive
     listener_ready ->
-      Opts = lists:keyreplace(idle_timeout_ms, 1, default_conn_opts(), {idle_timeout_ms, 1}),
+      Opts = lists:keyreplace(idle_timeout_ms, 1, default_conn_opts(), {idle_timeout_ms, 100}),
       {ok, Conn} = quicer:connect("localhost", Port, Opts, 5000),
-      timer:sleep(500),
+      timer:sleep(5000),
       {error, stm_open_error} = quicer:start_stream(Conn, []),
       SPid ! done
   end.
@@ -512,14 +515,14 @@ tc_setopt(Config) ->
     listener_ready ->
       Opts = lists:keyreplace(peer_bidi_stream_count, 1, default_conn_opts(), {peer_bidi_stream_count, 1}),
       {ok, Conn} = quicer:connect("localhost", Port, Opts, 5000),
-      {ok, Stm0} = quicer:start_stream(Conn, []),
+      {ok, Stm0} = quicer:start_stream(Conn, [{active, false}]),
       {ok, 4} = quicer:send(Stm0, <<"ping">>),
       {ok, Stm1} = quicer:start_stream(Conn, []),
       {ok, 4} = quicer:send(Stm1, <<"ping">>),
       {P, _} = spawn_monitor(fun () -> Owner ! quicer:recv(Stm1, 4) end),
       receive
-        _ ->
-          ct:fail("unexpected recv")
+        Any ->
+          ct:fail("unexpected recv ~p", [Any])
       after 1000 ->
           ok
       end,
@@ -633,10 +636,22 @@ simple_stream_server(Owner, Config, Port) ->
   {ok, L} = quicer:listen(Port, default_listen_opts(Config)),
   Owner ! listener_ready,
   {ok, Conn} = quicer:accept(L, [], 5000),
-  {ok, _Stream }= quicer:accept_stream(Conn, []),
+  {ok, _Stream}= quicer:accept_stream(Conn, [], 100),
   receive done ->
       quicer:close_listener(L),
       ok
+  end.
+
+ensure_server_exit_normal(MonRef) ->
+  ensure_server_exit_normal(MonRef, 3000).
+ensure_server_exit_normal(MonRef, Timeout) ->
+  receive
+    {'DOWN', MonRef, process, _, normal} ->
+      ok;
+    {'DOWN', MonRef, process, _, Other} ->
+      ct:fail("server exits abnormaly ~p ", [Other])
+  after Timeout ->
+      ct:fail("server still running", [])
   end.
 
 default_stream_opts() ->
@@ -664,6 +679,8 @@ wait_for_close(Stm) ->
       after 2000 ->
           receive Any ->
               ct:fail({unexpected_recv, Any})
+          after 0 ->
+              wait_for_close(Stm)
           end
       end
   end.


### PR DESCRIPTION
Old passive recv API  buffers message in process heap which is a hack.

This PR utilizes msquic `StreamReceiveComplete` and `StreamReceiveSetEnabled` API to make quicer support real passive receive.