### PR TITLE
avoid stream closing race

### DIFF
--- a/c_src/quicer_connection.c
+++ b/c_src/quicer_connection.c
@@ -448,6 +448,7 @@ close_connection1(ErlNifEnv *env,
   enif_mutex_lock(c_ctx->lock);
   if (!c_ctx->is_closed)
     {
+      c_ctx->is_closed = TRUE;
       MsQuic->ConnectionShutdown(c_ctx->Connection,
                                  //@todo, check rfc for the error code
                                  QUIC_CONNECTION_SHUTDOWN_FLAG_NONE,

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -69,11 +69,11 @@ init_s_ctx()
   // @todo would be better to useacceptor's env.
   s_ctx->env = enif_alloc_env();
   s_ctx->lock = enif_mutex_create("quicer:s_ctx");
-  s_ctx->closed = false;
-  s_ctx->is_wait_for_data = false;
+  s_ctx->is_closed = FALSE;
+  s_ctx->is_wait_for_data = FALSE;
   s_ctx->Buffer = NULL;
   s_ctx->BufferLen = 0;
-  s_ctx->is_buff_ready = false;
+  s_ctx->is_buff_ready = FALSE;
   return s_ctx;
 }
 

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -64,7 +64,7 @@ typedef struct
   ErlNifMonitor *owner_mon;
   ErlNifEnv *env; //@todo destruct env
   ErlNifMutex *lock;
-  BOOLEAN closed;
+  BOOLEAN is_closed;
   _CTX_CALLBACK_WRITE_ _CTX_NIF_READ_ uint8_t *Buffer;
   _CTX_CALLBACK_WRITE_ _CTX_NIF_READ_ uint64_t BufferLen;
   _CTX_CALLBACK_READ_ BOOLEAN is_wait_for_data;

--- a/c_src/quicer_stream.c
+++ b/c_src/quicer_stream.c
@@ -516,6 +516,7 @@ close_stream1(ErlNifEnv *env,
         {
           ret = ERROR_TUPLE_2(ETERM_INT(Status));
         }
+      s_ctx->closed = TRUE;
     }
   enif_mutex_unlock(s_ctx->lock);
   enif_release_resource(s_ctx);

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -358,7 +358,7 @@ tc_stream_send_after_conn_close(Config) ->
       {ok, Stm} = quicer:start_stream(Conn, []),
       {ok, {_, _}} = quicer:sockname(Stm),
       ok = quicer:close_connection(Conn),
-      {error, stm_send_error, _} = quicer:send(Stm, <<"ping">>),
+      {error, closed} = quicer:send(Stm, <<"ping">>),
       SPid ! done,
       ok = ensure_server_exit_normal(Ref)
   after 1000 ->


### PR DESCRIPTION
- mark stream close in NIF ctx
- skip sending if conn/strm is in the middle of closing