### PR TITLE
Dev/william/fix compile with cmake 3.20.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,6 @@ jobs:
       - uses: gleam-lang/setup-erlang@v1.1.2
         with:
           otp-version: ${{ matrix.otp }}
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.8
-        with:
-          cmake-version: '3.16.9'
       - name: release build with debug log off
         run: |
           sudo sysctl -w kernel.core_pattern=core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ elseif (CMAKE_SYSTEM_NAME MATCHES Darwin)
 endif()
 
 # @todo clean complier warnings in the code
-target_compile_options(quicer_static PUBLIC "-og" "-ggdb3" "-Wno-unused-variable")
+target_compile_options(quicer_static PUBLIC "-ggdb3" "-Wno-unused-variable")
 
 add_library(quicer_nif SHARED ${SOURCES})
 if (CMAKE_SYSTEM_NAME MATCHES Linux)


### PR DESCRIPTION
FIX issue #46 

- CI: don't use `jwlawson/actions-setup-cmake`
  becasue github action virtual-environments has newer CMake 3.20.5 now
  
- Fix compiling error detect in CMake 3.20
