### PR TITLE
ci: wrap tests with lttng trace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,24 @@ jobs:
           sudo sysctl -w kernel.core_pattern=core
           ulimit -c unlimited
           export CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          export QUIC_ENABLE_LOGGING=ON
+          sudo apt-add-repository ppa:lttng/stable-2.12
+          sudo apt-get update
+          sudo apt-get install -y lttng-tools lttng-modules-dkms babeltrace liblttng-ust-dev
+          which lttng
+          uname -a
+          mkdir msquic_lttng
+          lttng create msquic -o=./msquic_lttng
+          lttng enable-event --userspace CLOG_*
+          lttng add-context --userspace --type=vpid --type=vtid
+          lttng start
+
+          cleanup () {
+            lttng stop msquic;
+            babeltrace --names all ./msquic_lttng/* > _build/test/quic.babel.txt
+          }
+
+          trap "cleanup"  EXIT
           make ci
       - name: Archive CT Logs
         uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,3 +91,8 @@ set_target_properties(quicer_nif
     PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/priv/
 )
+
+
+if (QUIC_ENABLE_LOGGING)
+set_target_properties(msquic.lttng PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/priv)
+endif()

--- a/rebar.config
+++ b/rebar.config
@@ -8,12 +8,7 @@
    {"darwin", compile, "make -j `sysctl -n hw.ncpu` -C c_build"},
    {"darwin", compile, "cp priv/libquicer_nif.dylib priv/libquicer_nif.so"}
   ]}.
-{post_hooks,
-   %% todo: do it to CMake
-  [
-   %% {"(linux|darwin|solaris)", compile, "test -f c_build/msquic/bin/Debug/libmsquic.lttng.so &&"
-   %%  "cp c_build/msquic/bin/Debug/libmsquic.lttng.so priv/ || echo ok"}
-  ]}.
+
 {deps, [ {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
        ]}.
 


### PR DESCRIPTION
It provides lttng trace in the downloadable CommonTest log in case the CI is failed.