### PR TITLE
ci: lttng 2.13 and fix msquic.lttng outdir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           ulimit -c unlimited
           export CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           export QUIC_ENABLE_LOGGING=ON
-          sudo apt-add-repository ppa:lttng/stable-2.12
+          sudo apt-add-repository ppa:lttng/stable-2.13
           sudo apt-get update
           sudo apt-get install -y lttng-tools lttng-modules-dkms babeltrace liblttng-ust-dev
           which lttng

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ set_target_properties(quicer_nif
         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/priv/
 )
 
-
 if (QUIC_ENABLE_LOGGING)
-set_target_properties(msquic.lttng PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/priv)
+  set_target_properties(msquic.lttng PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/priv)
+  set_target_properties(msquic.lttng PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_SOURCE_DIR}/priv)
 endif()


### PR DESCRIPTION
Changes to adapt to new GitHub CI ubuntu-latest image.

- Update msquic.lttng debug lib outdir.
- Update to use lttng2.13