### PR TITLE
Add missing `pkgname.sh` script

### DIFF
--- a/src/quicer.app.src
+++ b/src/quicer.app.src
@@ -27,6 +27,7 @@
                   , "get-msquic.sh"
                   , "c_build"
                   , "build.sh"
+                  , "pkgname.sh"
                   ]},
   {exclude_regexps, ["priv/.*.so"]}
 


### PR DESCRIPTION
The hex.pm package is missing the `pkgname.sh` script and currently fails with:

```bash
./build.sh: line 7: ./pkgname.sh: No such file or directory
make: *** [Makefile:11: build-nif] Error 1
===> Hook for compile failed!

** (Mix) Could not compile dependency :quicer, "/Users/kevin/.asdf/installs/elixir/ref-main/.mix/elixir/1-15/rebar3 bare compile --paths /Users/kevin/Documents/repos/bandit/_build/dev/lib/*/ebin" command failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile quicer", update it with "mix deps.update quicer" or clean it with "mix deps.clean quicer"
```