### PR TITLE
Fixed potential segfault when certificate is a null pointer.

### DIFF
--- a/c_src/quicer_connection.c
+++ b/c_src/quicer_connection.c
@@ -1432,6 +1432,9 @@ handle_connection_event_peer_certificate_received(
       = (X509_STORE_CTX *)Event->PEER_CERTIFICATE_RECEIVED.Chain;
   STACK_OF(X509) *untrusted = X509_STORE_CTX_get0_untrusted(x509_ctx);
 
+  if (cert == NULL)
+      return QUIC_STATUS_BAD_CERTIFICATE;
+
   X509_STORE_CTX *ctx = X509_STORE_CTX_new();
   X509_STORE_CTX_init(ctx, c_ctx->trusted, cert, untrusted);
   int res = X509_verify_cert(ctx);


### PR DESCRIPTION
It turns out that the Certificate pointer may be null then QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED event is triggered.