### PR TITLE
Some sort of timing bug found, the sleep statement at line 222 in qt.…

### DIFF
--- a/test/example/Makefile
+++ b/test/example/Makefile
@@ -12,3 +12,9 @@ clean:
 
 lux:
 	lux .
+
+
+server:
+	erl -sname s -pa ../../_build/default/lib/quicer/ebin -s qt s
+client:
+	erl -sname c -pa ../../_build/default/lib/quicer/ebin

--- a/test/example/connect_stream.lux
+++ b/test/example/connect_stream.lux
@@ -1,0 +1,12 @@
+
+
+[include simple.inc]
+
+[shell client]
+    !{connect_stream, 1000}.
+    ?Stream 1
+    ?Stream 100
+    ?Stream 1000
+    ?-->
+
+


### PR DESCRIPTION
…erl seems to alleviate it.

If an active, false stream is created directly after connect, sometimes the server side still thinks its in active true mode. Timing related, works approx 50 % of the time.