### PR TITLE
Klacke/example nat site

### DIFF
--- a/test/example/Makefile
+++ b/test/example/Makefile
@@ -8,7 +8,7 @@ certs:
 	erl -noshell -s qt certs
 
 clean:
-	rm -rf *.beam *~ lux_logs *.key *.pem *.csr *.srl
+	rm -rf *.beam *~ lux_logs *.key *.pem *.csr *.srl *.dump
 
 lux:
 	lux .

--- a/test/example/connect_stream.lux
+++ b/test/example/connect_stream.lux
@@ -3,10 +3,10 @@
 [include simple.inc]
 
 [shell client]
-    !{connect_stream, 1000}.
+    !{connect_stream, 400}.
     ?Stream 1
     ?Stream 100
-    ?Stream 1000
+    ?Stream 400
     ?-->
 
 

--- a/test/example/die.lux
+++ b/test/example/die.lux
@@ -20,7 +20,7 @@
 
 [shell client]
     [sleep 1]
-    [loop _ 1 .. 20]
+    [loop _ 1..20]
 """@(?s)
 Stream 1 closed
 """

--- a/test/example/nat.lux
+++ b/test/example/nat.lux
@@ -1,0 +1,23 @@
+
+[global fail_pattern=[Ee][Rr][Rr][Oo][Rr]]
+[global eprompt=\d*>]
+
+[shell server]
+    !erl -pa ../../_build/default/lib/quicer/ebin
+    ?$eprompt
+    !Top = rev:start().
+    ?$eprompt
+    !Top ! connect.
+    ?Got pong 5
+    ?Got pong 1
+    ?Stream closed
+    ?$eprompt
+
+    # Adding a second call to the code, fails, thus
+    # commenting out the code below, the test works
+
+    !Top ! connect.
+    ?Got pong 5
+    ?Got pong 1
+    ?Stream closed
+    ?$eprompt

--- a/test/example/nat.lux
+++ b/test/example/nat.lux
@@ -13,9 +13,6 @@
     ?Stream closed
     ?$eprompt
 
-    # Adding a second call to the code, fails, thus
-    # commenting out the code below, the test works
-
     !Top ! connect.
     ?Got pong 5
     ?Got pong 1

--- a/test/example/rev.erl
+++ b/test/example/rev.erl
@@ -1,0 +1,137 @@
+-module(rev).
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("../../include/quicer.hrl").
+
+%% This is an axample of how we can revert connections. This is especially
+%% interesting when we want to connect to a device behind a NAT device.
+%% Code behind the NAT device can do connect(), and following that the
+%% code at the "top site" can do start_stream() to the device behind the NAT
+
+%% To run:
+
+%% > Top = rev:start().
+%% > Top ! connect.
+%% > Top ! connect.
+
+
+-define(INTERVAL, 3000).
+
+
+
+start() ->
+    application:ensure_all_started(quicer),
+    _C = proc_lib:spawn_link(fun() ->
+                                     nat_site()
+                             end),
+
+    Top = proc_lib:spawn_link(fun() ->
+                                      listener()
+                              end),
+    Top.
+
+listener() ->
+    Port = 4567,
+    LOptions = [ {cert, "./server.pem"}
+               , {key,  "./server.key"}
+               , {verify, none}
+               , {active, false}
+               , {handshake_idle_timeout_ms, 3 * ?INTERVAL}
+               , {keep_alive_interval_ms, ?INTERVAL}
+               , {alpn, ["sample"]}
+               , {idle_timeout_ms, 3 *?INTERVAL}
+               , {peer_bidi_stream_count, 64000}
+               ],
+
+    {ok, L} = quicer:listen(Port, LOptions),
+    {ok, Conn} = quicer:accept(L, [{active, false}], infinity),
+    {ok, Conn} = quicer:handshake(Conn),
+    r_loop(Conn).
+
+r_loop(Conn) ->
+    receive
+        connect ->
+            io:format("Starting stream downwards \n",[]),
+            {ok, S} = quicer:start_stream(Conn, [{active, false}]),
+            ok = quicer:setopt(S, active, 20),
+            ok = send_ping(5, S),
+            io:format("Closing stream \n",[]),
+            %ok = quicer:close_stream(S),
+            ok = quicer:async_close_stream(S),
+            io:format("Stream closed \n",[])
+    end,
+    r_loop(Conn).
+
+
+nat_site() ->
+    Port = 4567,
+    case quicer:connect("localhost", Port,
+                        [{alpn, ["sample"]},
+                         {verify, none},
+                         {keep_alive_interval_ms, ?INTERVAL},
+                         {handshake_idle_timeout_ms, 3 * ?INTERVAL},
+                         {idle_timeout_ms, 3 * ?INTERVAL}],
+                        10000) of
+        {ok, Conn} ->
+            a_loop(Conn);
+        _Err ->
+            timer:sleep(10),
+            nat_site()
+    end.
+
+a_loop(Conn) ->
+    {ok, Stream} = quicer:accept_stream(Conn, [{active, false}]),
+    P = proc_lib:spawn_link(fun() ->
+                                    stream_handler0(Stream)
+                            end),
+    ok = quicer:controlling_process(Stream, P),
+    P ! continue,
+    a_loop(Conn).
+
+
+stream_handler0(Stream) ->
+    io:format("Entering stream handler for ~p\n",[Stream]),
+    receive
+        continue ->
+            ok = quicer:setopt(Stream, active, 20),
+            stream_handler(Stream, 0),
+            io:format("Leaving stream handler \n",[]),
+            ok
+    end.
+
+stream_handler(S, N) ->
+    receive
+        {quic, passive, S, _} ->
+            io:format("Setting active 20\n",[]),
+            ok = quicer:setopt(S, active, 20),
+            stream_handler(S, N);
+        {quic, <<"ping">>, S,_} ->
+            io:format("Handler got ping ~p \n",[N]),
+            {ok, 4} = quicer:send(S, <<"pong">>),
+            stream_handler(S, N+1);
+        {quic, stream_closed, S, _X} ->
+            io:format("Handler got close stream \n",[]),
+            quicer:async_close_stream(S),
+            closed
+    end.
+
+send_ping(0, _) ->
+    ok;
+send_ping(N, S) ->
+    io:format("Sending ping \n",[]),
+    {ok, 4} = quicer:send(S, <<"ping">>),
+    rec_pong(N, S).
+rec_pong(N, S) ->
+    receive
+        {quic, <<"pong">>, S,_} ->
+            io:format("Got pong ~p\n",[N]),
+            send_ping(N-1, S);
+        {quic, passive, S, _} ->
+            io:format("Setting active 30 \n",[]),
+            ok = quicer:setopt(S, active, 30),
+            rec_pong(N, S);
+        {quic, stream_closed, S, _} ->
+            quicer:async_close_stream(S),
+            closed
+    end.

--- a/test/example/suspend.lux
+++ b/test/example/suspend.lux
@@ -22,7 +22,7 @@
 [shell client]
     !fg
     [sleep 1]
-    [loop _ 1 .. 20]
+    [loop _ 1..20]
 """@(?s)
 Conns = []
 Streams = []

--- a/test/example/suspend2.lux
+++ b/test/example/suspend2.lux
@@ -11,13 +11,13 @@
     -
     [timeout 60]
 
-    [loop _ 1 .. 30 ]
+    [loop _ 1..30 ]
       @Connection 1 closed
       !flush.
       ?-->
       [sleep 10]
     [endloop]
-    [loop _ 1 .. 20]
+    [loop _ 1..20]
 """@(?s)
 Conns = []
 Streams = []

--- a/test/example/suspend2.lux
+++ b/test/example/suspend2.lux
@@ -9,13 +9,13 @@
 
 [shell client]
     -
-    [timeout 30]
+    [timeout 60]
 
     [loop _ 1 .. 30 ]
       @Connection 1 closed
       !flush.
       ?-->
-      [sleep 5]
+      [sleep 10]
     [endloop]
     [loop _ 1 .. 20]
 """@(?s)


### PR DESCRIPTION
Hi William, I've stumbled upon more errors. Take a look at rev.erl  and nat.lux in this branch.

    The server does the initial accept() and following that
    The server calls start_stream(), and the original client calls
    accept_stream()
    
    Two possible bugs found with this example.
    
    1. The call to close on line 61 doesn't seem to go through
       to the other end.
    
    2. Look at the lux file, if the test  is run twice it doesn't work.
