### PR TITLE
feat(multi-streams): manageable  stream handoff

### DIFF
--- a/docs/messages_to_owner.md
+++ b/docs/messages_to_owner.md
@@ -64,7 +64,7 @@ Otherwise, start stream will be queued. Also see [peer_accepted](#peer_accepted)
 
 ```erlang
 {quic, start_complete, stream_handler(), #{ status := atom_status()
-                                          , stream_id := integer(), 
+                                          , stream_id := integer()
                                           , is_peer_accepted := boolean() }
 ```
 
@@ -75,7 +75,7 @@ Data received in binary format.
 
 ```erlang
 {quic, binary(), stream_handler(), #{ absolute_offset := integer() 
-                                    , len := integer()  
+                                    , len := integer()
                                     , flags := integer()} }
 ```
 
@@ -231,7 +231,7 @@ Connection has been shutdown by the transport locally, such as idle timeout.
 Peer side initiated connection shutdown.
 
 ``` erlang
-{quic, shutdown, connection_handler(), ErrorCode :: integer()}
+{quic, shutdown, connection_handler(), ErrorCode :: error_code()}
 ```
 
 ### Shutdown Complete
@@ -240,7 +240,7 @@ The connection has completed the shutdown process and is ready to be
 safely cleaned up.
 
 ``` erlang
-{quic, closed, connection_handler(), #{ is_handshake_completed := boolean()}
+{quic, closed, connection_handler(), #{ is_handshake_completed := boolean()
                                       , is_peer_acked := boolean()
                                       , is_app_closing := boolean()
                                       }} 

--- a/docs/messages_to_owner.md
+++ b/docs/messages_to_owner.md
@@ -276,7 +276,8 @@ This message is sent to notify the process that the process becomes the owner of
 
 When `is_orphan` is false, the process is selected as the owner because it is in the new stream acceptor list.
 
-When `is_orphan` is true, the connection owner process is selected because there is no available stream acceptor.
+When `is_orphan` is true, the connection owner process is selected because there is no available stream acceptor
+and the stream active mode is set to false (passive mode). 
 
 ### Streams available
 

--- a/docs/todo.org
+++ b/docs/todo.org
@@ -6,9 +6,7 @@
 
 Feature todo list, priority descending
 
-** Notify acceptors when listener/connecion is closed.
-
-** Handoff stream with the other signals
+** Notify acceptors when listener is closed.
 
 ** Stream behavior should able to handle multiple streams
 One process could become the owner of multiple streams in the scenario
@@ -46,8 +44,6 @@ API for registrationshutdown, shutdown all connections under registration
 ** NIF Upgrade
 
 * Improvements
-
-- Set stream to passive when handoff is needed.
 
 - send buffering
 

--- a/include/quicer_types.hrl
+++ b/include/quicer_types.hrl
@@ -153,6 +153,10 @@
                              , flags := stream_open_flags()
                              }.
 
+-type streams_available_props() :: #{ unidi_streams := non_neg_integer()
+                                    , bidi_streams := non_neg_integer()
+                                    }.
+
 -type send_complete_flag() :: ?QUIC_SEND_COMPLETE_SUCCESS |
                               ?QUIC_SEND_COMPLETE_CANCELLED.
 
@@ -271,19 +275,36 @@
                             , alpns := string() | undefined
                             }.
 
--type conn_closed_props() :: map().
+-type conn_closed_props() :: #{ is_handshake_completed := boolean()
+                              , is_peer_acked := boolean()
+                              , is_app_closing := boolean()
+                              }.
 
--type transport_shutdown_info() :: #{ is_conn_shutdown := boolean()
-                                    , is_app_closing := boolean()
-                                    , is_shutdown_by_app := boolean()
-                                    , is_closed_remotely := boolean()
-                                    , status := atom_reason()
-                                    , error := error_code()
-                                    }.
+-type transport_shutdown_props() :: #{ is_conn_shutdown := boolean()
+                                     , is_app_closing := boolean()
+                                     , is_shutdown_by_app := boolean()
+                                     , is_closed_remotely := boolean()
+                                     , status := atom_reason()
+                                     , error := error_code()
+                                     }.
 
 %% Stream Event Props
--type stream_start_completed_props() :: map().
+-type stream_start_completed_props() :: #{ status := atom()
+                                         , stream_id := integer()
+                                         , is_peer_accepted := boolean() }.
 -type stream_closed_props() :: map().
+
+-type peer_accepted_props() :: #{ is_conn_shutdown := boolean()
+                                , is_app_closing := boolean()
+                                , is_shutdown_by_app := boolean()
+                                , is_closed_remotely := boolean()
+                                , status := atom_reason()
+                                , error := error_code()
+                                }.
+
+-type recv_data_props() :: #{ absolute_offset := integer()
+                            , len := integer()
+                            , flags := integer()}.
 
 %% @doc QUIC Application error code, not protocol error code.
 %% The app error code will be passed to the peer while shutdown the connection.

--- a/include/quicer_types.hrl
+++ b/include/quicer_types.hrl
@@ -291,7 +291,8 @@
 %% Stream Event Props
 -type stream_start_completed_props() :: #{ status := atom()
                                          , stream_id := integer()
-                                         , is_peer_accepted := boolean() }.
+                                         , is_peer_accepted := boolean()
+                                         }.
 -type stream_closed_props() :: map().
 
 -type peer_accepted_props() :: #{ is_conn_shutdown := boolean()
@@ -304,7 +305,8 @@
 
 -type recv_data_props() :: #{ absolute_offset := integer()
                             , len := integer()
-                            , flags := integer()}.
+                            , flags := integer()
+                            }.
 
 %% @doc QUIC Application error code, not protocol error code.
 %% The app error code will be passed to the peer while shutdown the connection.

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -850,7 +850,7 @@ handoff_stream(_Stream, NewOwner, HandoffData) when NewOwner == self() ->
   NewOwner ! {handoff_done, HandoffData},
   ok;
 handoff_stream(Stream, NewOwner, HandoffData) ->
-  ?tp(debug, #{event=>?FUNCTION_NAME , module=>?MODULE, stream=>Stream, owner=>NewOwner}),
+  ?tp(debug, #{event=>?FUNCTION_NAME, module=>?MODULE, stream=>Stream, owner=>NewOwner}),
   case quicer:getopt(Stream, active) of
     {ok, ActiveN} ->
       ActiveN =/= false andalso quicer:setopt(Stream, active, false),

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -432,8 +432,6 @@ accept_stream(Conn, Opts) ->
 accept_stream(Conn, Opts, Timeout) when is_list(Opts) ->
   accept_stream(Conn, maps:from_list(Opts), Timeout);
 accept_stream(Conn, Opts, Timeout) when is_map(Opts) ->
-  % @todo make_ref
-  % @todo error handling
   NewOpts = maps:merge(default_stream_opts(), Opts),
   case quicer_nif:async_accept_stream(Conn, NewOpts) of
     {ok, Conn} ->

--- a/src/quicer_connection.erl
+++ b/src/quicer_connection.erl
@@ -28,7 +28,9 @@
 
 -behaviour(gen_server).
 
--export_type([cb_state/0]).
+-export_type([ cb_state/0
+             , cb_ret/0
+             ]).
 
 -type cb_state() :: quicer_lib:cb_state().
 

--- a/src/quicer_server_conn_callback.erl
+++ b/src/quicer_server_conn_callback.erl
@@ -77,8 +77,12 @@ new_stream(Stream, #{is_orphan := true} = StreamProps,
                                   SOpts, StreamProps)
     of
         {ok, StreamOwner} ->
-            quicer_connection:handoff_stream(Stream, StreamOwner),
-            {ok, CBState#{ streams := [ {StreamOwner, Stream} | Streams] }};
+            case quicer:handoff_stream(Stream, StreamOwner) of
+                ok ->
+                    {ok, CBState#{ streams := [ {StreamOwner, Stream} | Streams] }};
+                {error, _} = E ->
+                    E
+            end;
         Other ->
             Other
     end.

--- a/src/quicer_stream.erl
+++ b/src/quicer_stream.erl
@@ -24,6 +24,9 @@
 -callback init_handoff(stream_handle(), stream_opts(), connection_handle(), new_stream_props()) -> cb_ret().
 %% Prepare callback state before ownership handoff
 
+-callback post_handoff(stream_handle(), PostInfo::term(), cb_state()) -> cb_ret().
+%% Post handoff with PostData if any. Most common action is to set the stream mode to active.
+
 -callback new_stream(stream_handle(), new_stream_props(), connection_handle()) -> cb_ret().
 %% Stream accepter is assigned to the owner of the new stream
 
@@ -55,6 +58,18 @@
 
 -callback passive(stream_handle(), undefined, cb_state()) -> cb_ret().
 %% Stream now in 'passive' mode.
+
+
+-callback handle_call(Req::term(), gen_server:from(), cb_state()) -> cb_ret().
+%% Handle API call with callback state.
+
+-callback handle_continue(Cont::term(), cb_state()) -> cb_ret().
+%% Handle continue from other callbacks with callback state.
+
+-callback handle_info(Info::term(), cb_state()) -> cb_ret().
+%% Handle unhandled info with callback state.
+
+-optional_callbacks([post_handoff/3, handle_call/3, handle_info/2, handle_continue/2]).
 
 -import(quicer_lib, [default_cb_ret/2]).
 
@@ -142,14 +157,15 @@ send(StreamProc, Data, Flag) ->
 wait_for_handoff(FromOwner, Stream) ->
     MRef = erlang:monitor(process, FromOwner),
     receive
-        handoff_done ->
+        {handoff_done, PostInfo}->
             ?tp(debug, #{event=>stream_owner_handoff_done,
-                         module=>?MODULE, stream=>Stream
+                         module=>?MODULE, stream=>Stream,
+                         post_info=> PostInfo
                         }),
-            ok;
+            {ok, PostInfo};
         {'DOWN', MRef, process, FromOwner, _Info} ->
-            ?tp(debug, handoff_exit_down),
-            owner_down
+            ?tp(debug, handoff_exit_owner_down),
+            {error, owner_down}
     %% For correctness we should never add timeout
     end.
 
@@ -259,19 +275,11 @@ handle_call({send, Data, Flag}, _From,
     Res = quicer:async_send(Stream, Data, Flag),
     {reply, Res, State};
 
-handle_call(Request, _From,
-            #{stream := Stream,
+handle_call(Request, From,
+            #{stream := _Stream,
               callback := CallbackModule,
-              stream_opts := Options, callback_state := CallbackState} = State) ->
-    try CallbackModule:handle_call(Stream, Request, Options, CallbackState) of
-        {ok, Reply, NewCallbackState} ->
-            {reply, Reply, State#{ callback_state := NewCallbackState
-                                 , stream_opts := Options
-                                 }}
-    catch _:Reason:ST ->
-            maybe_log_stracetrace(ST),
-            {reply, {callback_error, Reason}, State}
-    end.
+              callback_state := CallbackState} = State) ->
+    default_cb_ret(CallbackModule:handle_call(Request, From, CallbackState), State).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -326,20 +334,11 @@ handle_info({quic, new_stream, Stream, #{flags := Flags, is_orphan := false} = P
             {stop, {new_stream_crash, Reason}, State#{stream := Stream}}
     end;
 handle_info({quic, Bin, Stream, #{flags := Flags}},
-            #{ stream := Stream, callback := CallbackModule
+            #{ stream := Stream, callback := M
              , callback_state := CallbackState } = State)
   when is_binary(Bin) ->
     ?tp(debug, stream_data, #{module=>?MODULE, stream=>Stream}),
-    try CallbackModule:handle_stream_data(Stream, Bin, Flags, CallbackState) of
-        {ok, NewCallbackState} ->
-            {noreply, State#{callback_state := NewCallbackState}};
-        {error, Reason, NewCallbackState} ->
-            {noreply, Reason, State#{callback_state := NewCallbackState}}
-    catch
-        _:Reason:ST ->
-            maybe_log_stracetrace(ST),
-            {stop, {handle_stream_data_crash, Reason}, State}
-    end;
+    default_cb_ret(M:handle_stream_data(Stream, Bin, Flags, CallbackState), State);
 
 handle_info({quic, start_completed, Stream,
              #{ status := _AtomStatus
@@ -398,7 +397,12 @@ handle_info({quic, passive, Stream, undefined},
             #{ callback := M
              , callback_state := CBState} = State) ->
     ?tp(debug, #{module=>?MODULE, event => passive}),
-    default_cb_ret(M:passive(Stream, CBState), State).
+    default_cb_ret(M:passive(Stream, CBState), State);
+handle_info(Info,
+            #{ callback := M
+             , callback_state := CBState} = State) ->
+    ?tp(debug, #{module=>?MODULE, event => info}),
+    default_cb_ret(M:handle_info(Info, CBState), State).
 
 %% @TODO  handle_info({EXIT....
 
@@ -414,19 +418,25 @@ handle_info({quic, passive, Stream, undefined},
           {noreply, state(), Timeout :: timeout()} |
           {noreply, state(), hibernate} |
           {stop, Reason :: normal | term(), state()}.
-handle_continue({?post_init, PrevOwner}, #{ is_owner := false, stream := Stream} = State) ->
+handle_continue({?post_init, PrevOwner}, #{ is_owner := false, stream := Stream
+                                          , callback_state := CBState
+                                          , callback := M} = State) ->
     ?tp(debug, #{event=>?post_init, module=>?MODULE, stream=>Stream}),
     case wait_for_handoff(PrevOwner, Stream) of
-        ok ->
-            quicer:setopt(Stream, active, true),
-            {noreply, State#{is_owner => true}};
-        owner_down ->
+        {ok, PostInfo}->
+            case erlang:function_exported(M, post_handoff, 3) of
+                true ->
+                    default_cb_ret(M:post_handoff(Stream, PostInfo, CBState), State#{is_owner => true});
+                false ->
+                    {noreply, State#{is_owner => true}}
+            end;
+        {error, owner_down} ->
             {stop, owner_down}
     end;
-handle_continue({?post_init, _}, #{ is_owner := true } = State) ->
-    logger:error("post_init when is owner"),
-    {stop, internal_error, State}.
-
+handle_continue(Other, #{ callback := M
+                        , callback_state := CBState} = State) ->
+    ?tp(debug, #{module=>?MODULE, event=>continue, stream=>maps:get(stream, State)}),
+    default_cb_ret(M:handle_continue(Other, CBState), State).
 %%--------------------------------------------------------------------
 %% @private
 %% @doc

--- a/test/example_client_stream.erl
+++ b/test/example_client_stream.erl
@@ -18,6 +18,7 @@
 -behavior(quicer_stream).
 
 -export([ init_handoff/4
+        , post_handoff/3
         , new_stream/3
         , start_completed/3
         , send_complete/3
@@ -28,7 +29,7 @@
         , stream_closed/3
         , peer_accepted/3
         , passive/3
-        , handle_call/4
+        , handle_call/3
         ]).
 
 -export([handle_stream_data/4]).
@@ -39,6 +40,10 @@
 init_handoff(_Stream, _StreamOpts, _Conn, _Flags) ->
     %% stream owner already set while starts.
     {stop, not_impl, #{}}.
+
+post_handoff(Stream, _PostData, State) ->
+    ok = quicer:setopt(Stream, active, true),
+    {ok, State}.
 
 new_stream(Stream, #{flags := Flags}, Conn) ->
     {ok, #{ stream => Stream, conn => Conn, is_local => false
@@ -105,8 +110,8 @@ passive(Stream, undefined, S)->
     ct:fail("Steam ~p go into passive mode", [Stream]),
     {ok, S}.
 
-handle_call(_Stream, _Request, _Opts, S) ->
-    {error, not_impl, S}.
+handle_call(_Request, _From, S) ->
+    {reply, {error, not_impl}, S}.
 
 stream_closed(_Stream, #{ is_conn_shutdown := IsConnShutdown
                         , is_app_closing := IsAppClosing

--- a/test/example_server_connection.erl
+++ b/test/example_server_connection.erl
@@ -89,8 +89,12 @@ new_stream(Stream, Flags, #{ conn := Conn, streams := Streams
     %% Spawn new stream
     case quicer_stream:start_link(example_server_stream, Stream, Conn, SOpts, Flags) of
         {ok, StreamOwner} ->
-            quicer_connection:handoff_stream(Stream, StreamOwner),
-            {ok, CBState#{ streams := [ {StreamOwner, Stream} | Streams] }};
+            case quicer:handoff_stream(Stream, StreamOwner) of
+                ok ->
+                    {ok, CBState#{ streams := [ {StreamOwner, Stream} | Streams ] }};
+                false ->
+                    {error, handoff_fail}
+            end;
         Other ->
             Other
     end.

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -130,6 +130,7 @@
         , tc_stream_start_flag_indicate_peer_accept_2/1
 
         , tc_stream_send_with_fin/1
+        , tc_stream_send_with_fin_passive/1
         , tc_stream_send_shutdown_complete/1
 
         %% insecure, msquic only
@@ -2083,6 +2084,56 @@ tc_stream_send_with_fin(Config) ->
   SPid ! done,
   ensure_server_exit_normal(Ref).
 
+tc_stream_send_with_fin_passive(Config) ->
+  Port = select_port(),
+  Owner = self(),
+  {SPid, Ref} = spawn_monitor(
+                  fun() ->
+                      echo_server(Owner, Config, Port)
+                  end),
+  receive
+    listener_ready ->
+      ok
+  after 5000 ->
+    ct:fail("listener_timeout")
+  end,
+  {ok, Conn} = quicer:connect("127.0.0.1", Port,
+                              default_conn_opts() ++ [{peer_unidi_stream_count, 1}], 5000),
+  {ok, Stm0} = quicer:start_stream(Conn, [{active, false}]),
+  {ok, 5} = quicer:send(Stm0, <<"ping1">>, ?QUIC_SEND_FLAG_FIN),
+  receive {quic, send_shutdown_complete, Stm0, true} -> ok end,
+  %% Since socket is passive we shall not get the stream data and stream close
+  receive
+    {quic, <<"ping1">>, Stm0, #{flags := Flag0}} ->
+      ct:fail("ping1 recvd with flag ~p ", [Flag0]);
+    {quic, _, Stm0, _} = Msg ->
+      ct:fail("recv unexpected msg: ~p", [Msg])
+  after 1000 ->
+      ct:pal("ping1 not received")
+  end,
+
+  quicer:setopt(Stm0, active, true),
+  receive
+    {quic, <<"ping1">>, Stm0, #{flags := Flag}} ->
+      ct:pal("ping1 recvd with flag ~p ", [Flag]),
+      ?assert(Flag band ?QUIC_RECEIVE_FLAG_FIN > 0);
+    {quic, _, Stm0, _} = Msg2 ->
+      ct:fail("recv unexpected msg: ~p", [Msg2])
+  after 1000 ->
+      ct:pal("ping1 not received")
+  end,
+
+  %% Check that stream close isn't caused by conn close.
+  receive
+    {quic, stream_closed, Stm0, #{is_conn_shutdown := IsConn}} ->
+      ?assert(not IsConn)
+  after 1000 ->
+      ct:fail("stream didn't close")
+  end,
+
+  SPid ! done,
+  ensure_server_exit_normal(Ref).
+
 tc_stream_send_shutdown_complete(Config) ->
   Port = select_port(),
   Owner = self(),
@@ -2368,18 +2419,24 @@ ping_pong_server_dgram(Owner, Config, Port) ->
     {ok, L} ->
       Owner ! listener_ready,
       {ok, Conn} = quicer:accept(L, [], 5000),
+      {ok, Conn} = quicer:async_accept_stream(Conn, []),
       {ok, Conn} = quicer:handshake(Conn),
-      {ok, Stm} = quicer:accept_stream(Conn, []),
-      ping_pong_server_dgram_loop(L, Conn, Stm);
+      ping_pong_server_dgram_loop(L, Conn);
     {error, listener_start_error, R} ->
       ct:pal("Failed to start listener:~p , retry ...", [R]),
       timer:sleep(100),
       ping_pong_server_dgram(Owner, Config, Port)
   end.
 
+ping_pong_server_dgram_loop(L, Conn) ->
+  receive
+    {quic, new_stream, Stm, _} ->
+      ping_pong_server_dgram_loop(L, Conn, Stm)
+  end.
+
 ping_pong_server_dgram_loop(L, Conn, Stm) ->
   receive
-    {quic, <<"ping">>, _, _} ->
+    {quic, <<"ping">>, Stm, _} ->
       ct:pal("send stream pong"),
       {ok, 4} = quicer:send(Stm, <<"pong">>),
       ping_pong_server_dgram_loop(L, Conn, Stm);

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -705,7 +705,10 @@ run_tc_conn_client_bad_cert(Config)->
           %% Depending on the timing, connection open could fail already.
           ok;
         {ok, Stm} ->
-          {ok, 4} = quicer:send(Stm, <<"ping">>),
+          case quicer:send(Stm, <<"ping">>) of
+            {ok, 4} -> ok;
+            {error, cancelled} -> ok
+          end,
           receive
             {quic, transport_shutdown, _Ref,
              #{error := _ErrorCode, status := bad_certificate}} ->

--- a/test/quicer_echo_server_stream_callback.erl
+++ b/test/quicer_echo_server_stream_callback.erl
@@ -18,6 +18,7 @@
 -behavior(quicer_stream).
 
 -export([ init_handoff/4
+        , post_handoff/3
         , new_stream/3
         , start_completed/3
         , send_complete/3
@@ -42,6 +43,10 @@ init_handoff(Stream, StreamOpts, Conn, #{is_orphan := true, flags := Flags}) ->
                  },
     ct:pal("init_handoff ~p", [{InitState, StreamOpts}]),
     {ok, InitState}.
+
+post_handoff(Stream, _PostData, State) ->
+    quicer:setopt(Stream, active, true),
+    {ok, State}.
 
 new_stream(_, _, _) ->
     InitState = #{sent_bytes => 0},

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -1445,7 +1445,7 @@ tc_accept_stream_active_once(Config) ->
                                 ?find_pairs(
                                    #{ ?snk_kind := debug
                                     , event := handoff_stream
-                                    , module := quicer_connection
+                                    , module := quicer
                                     , stream := _STREAM0
                                     },
                                    #{ ?snk_kind := debug
@@ -1539,7 +1539,7 @@ tc_accept_stream_active_N(Config) ->
                                 ?find_pairs(
                                    #{ ?snk_kind := debug
                                     , event := handoff_stream
-                                    , module := quicer_connection
+                                    , module := quicer
                                     , stream := _STREAM0
                                     },
                                    #{ ?snk_kind := debug
@@ -1588,7 +1588,7 @@ tc_multi_streams(Config) ->
                                 ?find_pairs(
                                    #{ ?snk_kind := debug
                                     , event := handoff_stream
-                                    , module := quicer_connection
+                                    , module := quicer
                                     , stream := _STREAM0
                                     },
                                    #{ ?snk_kind := debug
@@ -1671,7 +1671,7 @@ tc_multi_streams_example_server_1(Config) ->
                                 ?find_pairs(
                                    #{ ?snk_kind := debug
                                     , event := handoff_stream
-                                    , module := quicer_connection
+                                    , module := quicer
                                     , stream := _STREAM0
                                     },
                                    #{ ?snk_kind := debug
@@ -1683,7 +1683,7 @@ tc_multi_streams_example_server_1(Config) ->
                    ?assertMatch([{pair, _, _}],
                                 ?find_pairs( #{ ?snk_kind := debug
                                               , event := handoff_stream
-                                              , module := quicer_connection
+                                              , module := quicer
                                               },
                                              #{ ?snk_kind := debug
                                               , context := "nif"


### PR DESCRIPTION
- Orphan stream stay in passive mode before handoff to the new owner.
- Add post_handoff callback so prev owner could supply post hand off data to the new owner. 
- behaviors have new optional handle_call/handle_info/handle_continue callbacks.