### PR TITLE
fix(conn): flush closed event when sync conn fail

### DIFF
--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -483,6 +483,13 @@ tc_conn_basic_verify_peer_no_cacert(Config)->
 
   ?assert(ErrorStatus =:= cert_untrusted_root orelse ErrorStatus =:= bad_certificate),
 
+  receive
+    {quic, closed, _, _} ->
+      ct:fail("closed should be flushed")
+  after 500 ->
+      ok
+  end,
+
   SPid ! done,
   ensure_server_exit_normal(Ref),
   ok.

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -714,7 +714,8 @@ run_tc_conn_client_bad_cert(Config)->
         {ok, Stm} ->
           case quicer:send(Stm, <<"ping">>) of
             {ok, 4} -> ok;
-            {error, cancelled} -> ok
+            {error, cancelled} -> ok;
+            {error, stm_send_error, aborted} -> ok
           end,
           receive
             {quic, transport_shutdown, _Ref,


### PR DESCRIPTION
fix #150

When sync conn API call is failed after conn start, the conn closed event is useless to the caller because the handle
will not be presented to the caller.  the closed event is just non interesting junk in the proc mailbox.

This PR flush it before returns to the caller.

No changes in NIF because for client, no conn closed event will be sent if handshake is failed.