### PR TITLE
chore: drop noop optional callbacks impls

### DIFF
--- a/src/quicer_connection.erl
+++ b/src/quicer_connection.erl
@@ -133,11 +133,9 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, handle_continue/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2]).
 
 -import(quicer_lib, [default_cb_ret/2]).
-
--define(SERVER, ?MODULE).
 
 %%%===================================================================
 %%% API
@@ -451,34 +449,3 @@ handle_continue(Cont, #{callback := M,
                 State :: term()) -> any().
 terminate(_Reason, _State) ->
     ok.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Convert process state when code is changed
-%% @end
-%%--------------------------------------------------------------------
--spec code_change(OldVsn :: term() | {down, term()},
-                  State :: term(),
-                  Extra :: term()) -> {ok, NewState :: term()} |
-          {error, Reason :: term()}.
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% This function is called for changing the form and appearance
-%% of gen_server status when it is returned from sys:get_status/1,2
-%% or when it appears in termination error logs.
-%% @end
-%%--------------------------------------------------------------------
--spec format_status(Opt :: normal | terminate,
-                    Status :: list()) -> Status :: term().
-format_status(_Opt, Status) ->
-    Status.
-
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-

--- a/src/quicer_listener.erl
+++ b/src/quicer_listener.erl
@@ -25,9 +25,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
-
--define(SERVER, ?MODULE).
+         terminate/2]).
 
 -record(state, { name :: atom()
                , listener :: quicer:listener_handle()
@@ -160,33 +158,3 @@ terminate(_Reason, #state{listener = L}) ->
     %% nif listener has no owner process so we need to close it explicitly.
     quicer:close_listener(L),
     ok.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Convert process state when code is changed
-%% @end
-%%--------------------------------------------------------------------
--spec code_change(OldVsn :: term() | {down, term()},
-                  State :: term(),
-                  Extra :: term()) -> {ok, NewState :: term()} |
-          {error, Reason :: term()}.
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% This function is called for changing the form and appearance
-%% of gen_server status when it is returned from sys:get_status/1,2
-%% or when it appears in termination error logs.
-%% @end
-%%--------------------------------------------------------------------
--spec format_status(Opt :: normal | terminate,
-                    Status :: list()) -> Status :: term().
-format_status(_Opt, Status) ->
-    Status.
-
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================

--- a/src/quicer_stream.erl
+++ b/src/quicer_stream.erl
@@ -96,9 +96,8 @@
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          handle_continue/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2]).
 
--define(SERVER, ?MODULE).
 -define(post_init, post_init).
 
 -type state() :: #{ stream := quicer:stream_handle()
@@ -455,32 +454,6 @@ handle_continue(Other, #{ callback := M
 terminate(Reason, _State) ->
     error_code(Reason),
     ok.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Convert process state when code is changed
-%% @end
-%%--------------------------------------------------------------------
--spec code_change(OldVsn :: term() | {down, term()},
-                  term(),
-                  Extra :: term()) -> {ok, NewState :: term()} |
-          {error, Reason :: term()}.
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% This function is called for changing the form and appearance
-%% of gen_server status when it is returned from sys:get_status/1,2
-%% or when it appears in termination error logs.
-%% @end
-%%--------------------------------------------------------------------
--spec format_status(Opt :: normal | terminate,
-                    Status :: list()) -> Status :: term().
-format_status(_Opt, Status) ->
-    Status.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
The signature for `gen_server:format_status` callback have changed in OTP-25. Instead of updating implementations to support both signatures it's better to drop them altogether since they are no-ops.

Also remove few unused macrodefs.