### PR TITLE
feat(api): quicer:open_connection/0

### DIFF
--- a/c_src/quicer_connection.h
+++ b/c_src/quicer_connection.h
@@ -26,6 +26,8 @@ typedef enum QUICER_CONNECTION_EVENT_MASKS
 } QUICER_CONNECTION_EVENT_MASK;
 
 ERL_NIF_TERM
+open_connection0(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM
 async_connect3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM
 async_accept2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1362,6 +1362,7 @@ static ErlNifFunc nif_funcs[] = {
   { "reg_close", 0, deregistration, 0 },
   { "listen", 2, listen2, 0},
   { "close_listener", 1, close_listener1, 0},
+  { "open_connection", 0, open_connection0, 0},
   { "async_connect", 3, async_connect3, 0},
   { "async_accept", 2, async_accept2, 0},
   { "async_handshake", 1, async_handshake_1, 0},

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -94,6 +94,7 @@
 %% Exports for test
 -export([ get_conn_rid/1
         , get_stream_rid/1
+        , open_connection/0
         ]).
 
 -export([ start_listener/3 %% start application over quic
@@ -487,7 +488,7 @@ async_accept_stream(Conn, Opts) when is_map(Opts) ->
 %%
 %% Calling process becomes the owner of the stream.
 %%
-%% Both client and server could start the stream
+%% Both client and server could start the stream.
 %% @end
 -spec start_stream(connection_handle(), stream_opts()) ->
         {ok, stream_handle()} |
@@ -805,6 +806,10 @@ get_conn_rid(Conn) ->
         {ok, non_neg_integer()} | {error, any()}.
 get_stream_rid(Stream) ->
   quicer_nif:get_stream_rid(Stream).
+
+-spec open_connection() -> {ok, connection_handle()} | {error, atom_reason()}.
+open_connection() ->
+  quicer_nif:open_connection().
 
 %% @doc list all listeners
 -spec listeners() -> [{{ quicer_listener:listener_name()

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -42,6 +42,9 @@
         , get_stream_rid/1
         ]).
 
+%% For tests only
+-export([open_connection/0]).
+
 -on_load(init/0).
 
 -include_lib("kernel/include/file.hrl").
@@ -111,6 +114,10 @@ listen(_ListenOn, _Options) ->
 
 -spec close_listener(listener_handle()) -> ok.
 close_listener(_Listener) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+-spec open_connection() -> {ok, connection_handle()} | {error, atom_reason()}.
+open_connection() ->
   erlang:nif_error(nif_library_not_loaded).
 
 -spec async_connect(hostname(), inet:port_number(), conn_opts()) ->


### PR DESCRIPTION
- New API open_connection/0 for testing.

- Deprecated the method of resuming a connection from the old conn handle.