### PR TITLE
fix resource leaks in test

### DIFF
--- a/src/quicer_local_stream.erl
+++ b/src/quicer_local_stream.erl
@@ -51,7 +51,7 @@
 -callback passive(stream_handle(), undefined, cb_state()) -> cb_ret().
 %% Stream now in 'passive' mode.
 
--callback handle_stream_data(stream_handle(), binary(), recv_data_props(), cb_state() ) -> cb_ret().
+-callback handle_stream_data(stream_handle(), binary(), recv_data_props(), cb_state()) -> cb_ret().
 %% Stream handle data
 
 -callback handle_call(Req::term(), gen_server:from(), cb_state()) -> cb_ret().

--- a/src/quicer_remote_stream.erl
+++ b/src/quicer_remote_stream.erl
@@ -49,7 +49,7 @@
 -callback passive(stream_handle(), undefined, cb_state()) -> cb_ret().
 %% Stream now in 'passive' mode.
 
--callback handle_stream_data(stream_handle(), binary(), recv_data_props(), cb_state() ) -> cb_ret().
+-callback handle_stream_data(stream_handle(), binary(), recv_data_props(), cb_state()) -> cb_ret().
 %% Stream handle data
 
 -callback handle_call(Req::term(), gen_server:from(), cb_state()) -> cb_ret().

--- a/src/quicer_server_conn_callback.erl
+++ b/src/quicer_server_conn_callback.erl
@@ -46,7 +46,7 @@ init(ConnOpts) when is_map(ConnOpts) ->
     {ok, ConnOpts}.
 
 closed(_Conn, #{} = _Flags, S)->
-    {ok, S}.
+    {stop, normal, S}.
 
 new_conn(Conn, #{version := _Vsn}, #{stream_opts := SOpts} = S) ->
     %% @TODO configurable behavior of spawning stream acceptor

--- a/test/example_server_connection.erl
+++ b/test/example_server_connection.erl
@@ -56,10 +56,8 @@ init(#{stream_opts := SOpts} = S) when is_list(SOpts) ->
 init(ConnOpts) when is_map(ConnOpts) ->
     {ok, ConnOpts}.
 
-closed(_Conn, #{is_peer_acked := true}, S)->
-    {stop, normal, S};
-closed(_Conn, #{is_peer_acked := false}, S)->
-    {stop, abnorml, S}.
+closed(_Conn, _CloseProp, S) ->
+    {stop, normal, S}.
 
 new_conn(Conn, #{version := _Vsn}, #{stream_opts := SOpts} = S) ->
     case quicer_stream:start_link(example_server_stream, Conn, SOpts) of

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -228,7 +228,8 @@ end_per_testcase(tc_open_listener_neg_1, _Config) ->
   quicer:reg_open();
 end_per_testcase(_TestCase, _Config) ->
   quicer:stop_listener(mqtt),
-  ct:pal("What left in the message queue: ~p", [receive_all()]),
+  Unhandled = quicer_test_lib:receive_all(),
+  Unhandled =/= [] andalso ct:comment("What left in the message queue: ~p", [Unhandled]),
   ok.
 
 %%%===================================================================
@@ -2445,7 +2446,7 @@ tc_direct_send_over_conn_fail(Config) ->
 
   receive
     {quic, start_completed, StmX,
-     #{status := StartStatusX, stream_id := StreamIdX}} ->
+     #{status := StartStatusX, stream_id := StreamIdX}} when StmX =/= Stm0 ->
       ct:fail("Stream id: ~p started: ~p", [StreamIdX, StartStatusX])
   after 100 ->
       ok
@@ -2857,17 +2858,6 @@ flush_streams_available(Conn) ->
   receive
     {quic, streams_available, Conn,
      #{bidi_streams := _, unidi_streams := _}} -> ok
-  end.
-
-receive_all() ->
-  receive_all([]).
-
-receive_all(Res)->
-  receive
-    X ->
-      receive_all([X|Res])
-  after 0 ->
-      Res
   end.
 
 filename(Path, F, A) ->

--- a/test/quicer_echo_server_stream_callback.erl
+++ b/test/quicer_echo_server_stream_callback.erl
@@ -87,4 +87,4 @@ handle_call(_Stream, _Request, _Opts, _CBState) ->
     ok.
 
 stream_closed(_Stream, _Flags, S) ->
-    {ok, S}.
+    {stop, normal, S}.

--- a/test/quicer_test_lib.erl
+++ b/test/quicer_test_lib.erl
@@ -19,7 +19,9 @@
 
 
 -export([gen_ca/2,
-         gen_host_cert/3]).
+         gen_host_cert/3,
+         receive_all/0
+        ]).
 
 gen_ca(Path, Name) ->
   %% Generate ca.pem and ca.key which will be used to generate certs
@@ -87,6 +89,16 @@ create_file(Filename, Fmt, Args) ->
   end,
   ok.
 
+receive_all() ->
+  receive_all([]).
+
+receive_all(Res)->
+  receive
+    X ->
+      receive_all([X|Res])
+  after 0 ->
+      lists:reverse(Res)
+  end.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:


### PR DESCRIPTION
mem check tool reports some indirect mem leak due to

- some owner process is not stopped in some testcase
- some connection isn't aborted after test
- some uninterested signals from quic are not consumed from mailbox of CT process. 

