### PR TITLE
feat: stop then start listener

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -726,18 +726,17 @@ encode_parm_to_eterm(ErlNifEnv *env,
                    || QUIC_PARAM_GLOBAL_RETRY_MEMORY_PERCENT == Param)))
     {
       if (BufferLength == sizeof(uint64_t))
-      {
-        res = SUCCESS(ETERM_UINT_64(*(uint64_t *)Buffer));
-      }
+        {
+          res = SUCCESS(ETERM_UINT_64(*(uint64_t *)Buffer));
+        }
       else if (BufferLength == sizeof(uint32_t))
-      {
-        res = SUCCESS(ETERM_INT(*(uint32_t *)Buffer));
-      }
+        {
+          res = SUCCESS(ETERM_INT(*(uint32_t *)Buffer));
+        }
       else if (BufferLength == sizeof(uint16_t))
-      {
-        res = SUCCESS(ETERM_INT(*(uint16_t *)Buffer));
-      }
-
+        {
+          res = SUCCESS(ETERM_INT(*(uint16_t *)Buffer));
+        }
     }
   else if ((QUICER_PARAM_HANDLE_TYPE_CONN == Type
             && (QUIC_PARAM_CONN_REMOTE_ADDRESS == Param

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -53,6 +53,10 @@ deinit_l_ctx(QuicerListenerCTX *l_ctx)
 void
 destroy_l_ctx(QuicerListenerCTX *l_ctx)
 {
+  // @note, Destroy config asap as it holds rundown
+  // ref count in registration
+  destroy_config_ctx(l_ctx->config_resource);
+  l_ctx->config_resource = NULL;
   enif_release_resource(l_ctx);
 }
 

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -49,6 +49,7 @@ typedef struct QuicerListenerCTX
   // Listener handle closed flag
   // false means the handle is invalid
   BOOLEAN is_closed;
+  BOOLEAN is_stopped;
   BOOLEAN allow_insecure;
   void *reserved1;
   void *reserved2;

--- a/c_src/quicer_listener.h
+++ b/c_src/quicer_listener.h
@@ -25,6 +25,13 @@ QUIC_STATUS ServerListenerCallback(HQUIC Listener,
                                    QUIC_LISTENER_EVENT *Event);
 
 ERL_NIF_TERM listen2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM
+start_listener3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM
+stop_listener1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
 ERL_NIF_TERM
 close_listener1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1419,6 +1419,8 @@ static ErlNifFunc nif_funcs[] = {
   { "reg_open", 1, registration, 0 },
   { "reg_close", 0, deregistration, 0 },
   { "listen", 2, listen2, 0},
+  { "start_listener", 3, start_listener3, 0},
+  { "stop_listener", 1, stop_listener1, 0},
   { "close_listener", 1, close_listener1, 0},
   { "open_connection", 0, open_connection0, 0},
   { "async_connect", 3, async_connect3, 0},

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -32,7 +32,10 @@
 
 %% Traffic APIs
 -export([ listen/2
+        , stop_listen/1
+        , start_listen/3
         , close_listener/1
+        , close_listener/2
         , connect/4
         , async_connect/3
         , handshake/1
@@ -168,18 +171,38 @@ reg_open(Profile) ->
 reg_close() ->
   quicer_nif:reg_close().
 
--spec start_listener(Appname :: atom(), listen_on(),
+-spec start_listener(Appname :: atom() | listener_handle(), listen_on(),
                      {listener_opts(),
                       connection_opts(),
                       stream_opts() | user_opts()}
                     ) ->
         {ok, pid()} | {error, any()}.
-start_listener(AppName, Port, Options) ->
+start_listener(AppName, Port, Options) when is_atom(AppName) ->
   quicer_listener:start_listener(AppName, Port, Options).
 
--spec stop_listener(atom()) -> ok.
-stop_listener(AppName) ->
+-spec start_listen(listener_handle(), listen_on(), listen_opts()) ->
+        {ok, pid()} | {error, any()}.
+start_listen(Listener, Port, Options) when is_list(Options)->
+  start_listen(Listener, Port, maps:from_list(Options));
+start_listen(Listener, Port, Options) ->
+  quicer_nif:start_listener(Listener, Port, Options).
+
+-spec stop_listener(atom() | listener_handle()) -> ok.
+stop_listener(AppName) when is_atom(AppName)->
   quicer_listener:stop_listener(AppName).
+
+-spec stop_listen(listener_handle()) -> ok.
+stop_listen(Handle) ->
+  case quicer_nif:stop_listener(Handle) of
+    ok ->
+      receive
+        {quic, listener_stopped, Handle} ->
+          ok
+      end;
+    %% @TODO handle already stopped
+    {error, Reason} ->
+      {error, Reason}
+  end.
 
 %% @doc Start listen on Port or "HOST:PORT".
 %%
@@ -202,9 +225,30 @@ listen(ListenOn, Opts) when is_map(Opts) ->
   quicer_nif:listen(ListenOn, Opts).
 
 %% @doc close listener with listener handle
--spec close_listener(listener_handle()) -> ok.
+-spec close_listener(listener_handle()) -> ok | {error, badarg | closed | timeout}.
 close_listener(Listener) ->
-  quicer_nif:close_listener(Listener).
+  close_listener(Listener, 5000).
+
+-spec close_listener(listener_handle(), timer:time()) ->
+        ok | {error, badarg | closed | timeout}.
+close_listener(Listener, Timeout) ->
+  case quicer_nif:close_listener(Listener) of
+    ok when Timeout == 0 ->
+      ok;
+    ok ->
+      receive
+        {quic, listener_stopped, Listener} ->
+          ok
+      after Timeout ->
+          {error, timeout}
+      end;
+    {error, closed} ->
+      %% already closed
+      %% follow OTP behavior
+      ok;
+    {error, _} = E->
+      E
+  end.
 
 %% @doc
 %% Initiate New Connection (Client)

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -20,6 +20,8 @@
         , reg_open/1
         , reg_close/0
         , listen/2
+        , start_listener/3
+        , stop_listener/1
         , close_listener/1
         , async_connect/3
         , async_accept/2
@@ -113,8 +115,16 @@ reg_close() ->
 listen(_ListenOn, _Options) ->
   erlang:nif_error(nif_library_not_loaded).
 
--spec close_listener(listener_handle()) -> ok.
+-spec start_listener(listener_handle(), listen_on(), listen_opts()) -> ok | {error, closed | badarg}.
+start_listener(_Listener, _ListenOn, _Opts) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+-spec close_listener(listener_handle()) -> ok | {error, closed | badarg}.
 close_listener(_Listener) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+-spec stop_listener(listener_handle()) -> ok | {error, closed | badarg}.
+stop_listener(_Listener) ->
   erlang:nif_error(nif_library_not_loaded).
 
 -spec open_connection() -> {ok, connection_handle()} | {error, atom_reason()}.

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -145,7 +145,7 @@ init_per_testcase(_TestCase, Config) ->
 %% @end
 %%--------------------------------------------------------------------
 end_per_testcase(_TestCase, _Config) ->
-  quicer:stop_listener(mqtt),
+  quicer:terminate_listener(mqtt),
   snabbkaffe:cleanup(),
   Unhandled = quicer_test_lib:receive_all(),
   Unhandled =/= [] andalso ct:comment("What left in the message queue: ~p", [Unhandled]),
@@ -270,7 +270,7 @@ tc_app_echo_server(Config) ->
 
   quicer:close_stream(Stm),
   quicer:close_connection(Conn),
-  ok = quicer:stop_listener(mqtt).
+  ok = quicer:terminate_listener(mqtt).
 
 tc_slow_conn(Config) ->
   Port = select_port(),
@@ -294,7 +294,7 @@ tc_slow_conn(Config) ->
                  ct:pal("closing conn"),
                  quicer:close_connection(Conn),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -348,7 +348,7 @@ tc_stream_owner_down(Config) ->
                                 function := "ClientStreamCallback", mark := ?QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE,
                                 tag := "event"}, 1000, 1000)),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -435,7 +435,7 @@ tc_conn_owner_down(Config) ->
                            ?block_until(
                               #{?snk_kind := debug, event := closed, module := quicer_connection}, 1000, 1000)),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt),
+                 ok = quicer:terminate_listener(mqtt),
                  {ok, CRid} = quicer:get_conn_rid(Conn),
                  {CRid, SRid}
                end,
@@ -549,7 +549,7 @@ tc_conn_close_flag_1(Config) ->
                                , mark := ?QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE
                                , tag := "event"}, 1000, 3000),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt),
+                 ok = quicer:terminate_listener(mqtt),
                  {CRid, SRid}
                end,
                fun({_CRid, SRid}, Trace) ->
@@ -600,7 +600,7 @@ tc_conn_close_flag_2(Config) ->
                                , mark := ?QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE
                                , tag := "event"}, 3000, 3000), %% assume idle_timeout_is 5s
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -645,7 +645,7 @@ tc_stream_close_errno(Config) ->
                                , error_code := 1234
                                }, 1000, 1000),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -752,7 +752,7 @@ tc_conn_idle_close(Config) ->
                                              Trace))
                      end),
   ct:pal("stop listener"),
-  ok = quicer:stop_listener(mqtt),
+  ok = quicer:terminate_listener(mqtt),
   ok.
 
 tc_conn_gc(Config) ->
@@ -871,7 +871,7 @@ tc_conn_gc(Config) ->
                                )
                end),
   ct:pal("stop listener"),
-  ok = quicer:stop_listener(mqtt),
+  ok = quicer:terminate_listener(mqtt),
   ok.
 
 
@@ -970,7 +970,7 @@ tc_conn_no_gc(Config) ->
                   ?assert(Conn =/= undefined)
                end),
   ct:pal("stop listener"),
-  ok = quicer:stop_listener(mqtt),
+  ok = quicer:terminate_listener(mqtt),
   ok.
 
 tc_conn_no_gc_2(Config) ->
@@ -1087,7 +1087,7 @@ tc_conn_no_gc_2(Config) ->
                                                   } = E <- TraceEvents, Rid == CRid]))
                end),
   ct:pal("stop listener"),
-  ok = quicer:stop_listener(mqtt),
+  ok = quicer:terminate_listener(mqtt),
   ok.
 
 %%% Resume connection with connection opt: `nst'
@@ -1135,7 +1135,7 @@ tc_conn_resume_nst(Config) ->
                  {ok, <<"ping3">>} = quicer:recv(Stm2, 5),
                  quicer:shutdown_connection(Conn),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -1208,7 +1208,7 @@ tc_conn_resume_nst_with_stream(Config) ->
                  {ok, <<"ping3">>} = quicer:recv(Stm2, 5),
                  quicer:shutdown_connection(ConnResumed),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -1281,7 +1281,7 @@ tc_conn_resume_nst_async(Config) ->
                  {ok, <<"ping3">>} = quicer:recv(Stm2, 5),
                  ct:pal("stop listener"),
                  quicer:shutdown_connection(ConnResumed),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -1355,7 +1355,7 @@ tc_conn_resume_nst_async_2(Config) ->
                  {ok, <<"ping3">>} = quicer:recv(Stm2, 5),
                  ct:pal("stop listener"),
                  quicer:shutdown_connection(ConnResumed),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -1443,7 +1443,7 @@ tc_conn_resume_nst_with_data(Config) ->
                  ?assertNotEqual(NST2, NST),
 
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),
@@ -1517,7 +1517,7 @@ tc_listener_no_acceptor(Config) ->
                  {error, transport_down, #{status := connection_refused}}
                    = quicer:connect("localhost", Port, default_conn_opts(), 5000),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt),
+                 ok = quicer:terminate_listener(mqtt),
                  timer:sleep(5000)
                end,
                fun(_Result, Trace) ->
@@ -1655,7 +1655,7 @@ tc_accept_stream_active_once(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  {ok, Conn} = quicer:connect("localhost", Port,
                                              [{peer_bidi_stream_count, 10}, {peer_unidi_stream_count, 1} | default_conn_opts()], 5000),
 
@@ -1722,7 +1722,7 @@ tc_accept_stream_active_N(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  {ok, Conn} = quicer:connect("localhost", Port,
                                              [{peer_bidi_stream_count, 10}, {peer_unidi_stream_count, 1} | default_conn_opts()], 5000),
                  {ok, Stm} = quicer:start_stream(Conn, [{active, true}]),
@@ -1814,7 +1814,7 @@ tc_multi_streams(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  {ok, Conn} = quicer:connect("localhost", Port,
                                              [{peer_bidi_stream_count, 10} | default_conn_opts()], 5000),
                  {ok, Stm} = quicer:start_stream(Conn, [{active, true}]),
@@ -1867,7 +1867,7 @@ tc_multi_streams_example_server_1(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  {ok, Conn} = quicer:connect("localhost", Port,
                                              [{peer_bidi_stream_count, 10}, {peer_unidi_stream_count, 1} | default_conn_opts()], 5000),
                  {ok, Stm} = quicer:start_stream(Conn, [{active, true}]),
@@ -1962,7 +1962,7 @@ tc_multi_streams_example_server_2(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  ClientConnOpts = [{quic_event_mask, ?QUICER_CONNECTION_EVENT_MASK_NST} | default_conn_opts()],
                  {ok, ClientConnPid} = example_client_connection:start_link("localhost", Port,
                                                                    {ClientConnOpts, default_stream_opts()}),
@@ -2022,7 +2022,7 @@ tc_multi_streams_example_server_3(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  ClientConnOpts = [{quic_event_mask, ?QUICER_CONNECTION_EVENT_MASK_NST} | default_conn_opts()],
                  {ok, ClientConnPid} = example_client_connection:start_link("localhost", Port,
                                                                    {ClientConnOpts, default_stream_opts()}),
@@ -2183,7 +2183,7 @@ tc_passive_recv_1(Config) ->
   ct:pal("Listener Options: ~p", [Options]),
   ?check_trace(#{timetrap => 10000},
                begin
-                 {ok, _QuicApp} = quicer:start_listener(mqtt, Port, Options),
+                 {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
                  {ok, Conn} = quicer:connect("localhost", Port,
                                              [{peer_bidi_stream_count, 10}, {peer_unidi_stream_count, 1} | default_conn_opts()], 5000),
                  {ok, Stm} = quicer:start_stream(Conn, [{active, true}]),
@@ -2256,7 +2256,7 @@ select_port()->
 quicer_start_listener(Name, Port, Options)->
   quicer_start_listener(Name, Port, Options, 10).
 quicer_start_listener(Name, Port, Options, N) ->
-  case quicer:start_listener(mqtt, Port, Options) of
+  case quicer:spawn_listener(mqtt, Port, Options) of
     {ok, QuicApp} -> {ok, QuicApp};
     {error, listener_start_error, address_in_use} when N > 0 ->
       %% addr in use, retry....


### PR DESCRIPTION
Improve listener API,
- add API to stop and restart the listener with Listener handle
- fix config resource leaks in listener
- rename start_listener to spawn listener for supervised listener
- rename stop_listener to terminate listener for supervised listener
