### PR TITLE
perf(tls): share trusted store

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -2440,3 +2440,37 @@ get_str_from_map(ErlNifEnv *env,
 
   return enif_get_string(env, tmp_term, buff, tmp_len + 1, ERL_NIF_LATIN1);
 }
+
+BOOLEAN
+build_trustedstore(const char *cacertfile, X509_STORE **trusted_store)
+{
+  X509_STORE *store = NULL;
+  X509_LOOKUP *lookup = NULL;
+
+  if (cacertfile == NULL)
+    {
+      return FALSE;
+    }
+
+  store = X509_STORE_new();
+  if (store == NULL)
+    {
+      return FALSE;
+    }
+
+  lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
+  if (lookup == NULL)
+    {
+      X509_STORE_free(store);
+      return FALSE;
+    }
+
+  if (!X509_LOOKUP_load_file(lookup, cacertfile, X509_FILETYPE_PEM))
+    {
+      X509_STORE_free(store);
+      return FALSE;
+    }
+
+  *trusted_store = store;
+  return TRUE;
+}

--- a/c_src/quicer_config.h
+++ b/c_src/quicer_config.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "quicer_internal.h"
 #include "quicer_nif.h"
 #include <msquichelper.h>
+#include <openssl/x509.h>
 
 #ifdef DEBUG
 #define dbg(fmt, ...)                                                         \
@@ -116,5 +117,7 @@ ERL_NIF_TERM set_connection_opt(ErlNifEnv *env,
                                 ERL_NIF_TERM optname,
                                 ERL_NIF_TERM optval,
                                 ERL_NIF_TERM elevel);
+
+BOOLEAN build_trustedstore(const char *cacertfile, X509_STORE **trusted_store);
 
 #endif // __QUICER_CONFIG_H_

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -33,6 +33,7 @@ init_l_ctx()
   l_ctx->acceptor_queue = AcceptorQueueNew();
   l_ctx->lock = enif_mutex_create("quicer:l_ctx");
   l_ctx->cacertfile = NULL;
+  l_ctx->trusted_store = NULL;
   l_ctx->is_closed = TRUE;
   l_ctx->allow_insecure = FALSE;
   return l_ctx;
@@ -41,6 +42,10 @@ init_l_ctx()
 void
 deinit_l_ctx(QuicerListenerCTX *l_ctx)
 {
+  if (l_ctx->trusted_store)
+    {
+      X509_STORE_free(l_ctx->trusted_store);
+    }
   AcceptorQueueDestroy(l_ctx->acceptor_queue);
   if (l_ctx->config_resource)
     {

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -46,6 +46,7 @@ typedef struct QuicerListenerCTX
   ErlNifEnv *env;
   ErlNifMutex *lock;
   char *cacertfile;
+  X509_STORE *trusted_store;
   // Listener handle closed flag
   // false means the handle is invalid
   BOOLEAN is_closed;

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -382,9 +382,8 @@ tc_open_listener_inval_cacertfile_1(Config) ->
 
 tc_open_listener_inval_cacertfile_2(Config) ->
   Port = select_port(),
-  {ok, L} = quicer:listen(Port, [ {cacertfile, [1,2,3,4]}
+  {error, badarg} = quicer:listen(Port, [ {cacertfile, [1,2,3,4]}
                                 | default_listen_opts(Config)]),
-  ok = quicer:close_listener(L),
   ok.
 
 tc_open_listener_inval_cacertfile_3(Config) ->

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -725,7 +725,7 @@ tc_stream_shutdown_abort(Config) ->
                                , error_code := 1234
                                }, 1000, 1000),
                  ct:pal("stop listener"),
-                 ok = quicer:stop_listener(mqtt)
+                 ok = quicer:terminate_listener(mqtt)
                end,
                fun(Result, Trace) ->
                    ct:pal("Trace is ~p", [Trace]),


### PR DESCRIPTION
while accepting new conn, the listener no longer creates trusted store per connection that should reduce per-connection resource usage.