### PR TITLE
support multi execution registrations 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           key: brew-${{ matrix.os }}-${{ matrix.otp  }}
       - name: prepare
         run: |
-          #brew update
+          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           brew install erlang@${{ matrix.otp }}
       - name: install rebar3
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ set(SOURCES
   c_src/quicer_nif.c
   c_src/quicer_nif.h
   c_src/quicer_eterms.h
+  c_src/quicer_reg.c
+  c_src/quicer_reg.h
   c_src/quicer_config.c
   c_src/quicer_config.h
   c_src/quicer_queue.c

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -18,6 +18,35 @@ limitations under the License.
 
 // alloc/dealloc ctx should be done in the callbacks.
 
+QuicerRegistrationCTX *
+init_r_ctx()
+{
+  QuicerRegistrationCTX *r_ctx
+      = enif_alloc_resource(ctx_reg_t, sizeof(QuicerRegistrationCTX));
+  if (!r_ctx)
+    {
+      return NULL;
+    }
+  CxPlatZeroMemory(r_ctx, sizeof(QuicerRegistrationCTX));
+  r_ctx->env = enif_alloc_env();
+  r_ctx->Registration = NULL;
+  r_ctx->is_released = FALSE;
+  return r_ctx;
+}
+
+void
+deinit_r_ctx(QuicerRegistrationCTX *r_ctx)
+{
+  enif_free_env(r_ctx->env);
+}
+
+void
+destroy_r_ctx(QuicerRegistrationCTX *r_ctx)
+{
+  r_ctx->is_released = TRUE;
+  enif_release_resource(r_ctx);
+}
+
 QuicerListenerCTX *
 init_l_ctx()
 {

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -28,6 +28,16 @@ limitations under the License.
 #define _CTX_NIF_READ_
 
 /*
+ * Registration
+ */
+typedef struct QuicerRegistrationCTX
+{
+  ErlNifEnv *env;
+  HQUIC Registration;
+  BOOLEAN is_released;
+} QuicerRegistrationCTX;
+
+/*
  * Configuration
  */
 typedef struct QuicerConfigCTX
@@ -122,6 +132,10 @@ typedef struct QuicerStreamSendCTX
 } QuicerStreamSendCTX;
 
 typedef struct QuicerStreamSendCTX QuicerDgramSendCTX;
+
+QuicerRegistrationCTX *init_r_ctx();
+void deinit_r_ctx(QuicerRegistrationCTX *r_ctx);
+void destroy_r_ctx(QuicerRegistrationCTX *r_ctx);
 
 QuicerListenerCTX *init_l_ctx();
 void deinit_l_ctx(QuicerListenerCTX *l_ctx);

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -35,6 +35,7 @@ typedef struct QuicerRegistrationCTX
   ErlNifEnv *env;
   HQUIC Registration;
   BOOLEAN is_released;
+  char name[UINT8_MAX + 1];
 } QuicerRegistrationCTX;
 
 /*

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -493,11 +493,11 @@ ERL_NIF_TERM ATOM_UNDEFINED;
   ATOM(ATOM_QUIC_EXECUTION_PROFILE_LOW_LATENCY,                               \
        quic_execution_profile_low_latency);                                   \
   ATOM(ATOM_QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT,                       \
-       quic_execution_profile_type_max_throughput);                           \
+       quic_execution_profile_max_throughput);                                \
   ATOM(ATOM_QUIC_EXECUTION_PROFILE_TYPE_SCAVENGER,                            \
-       quic_execution_profile_type_scavenger);                                \
+       quic_execution_profile_scavenger);                                     \
   ATOM(ATOM_QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME,                            \
-       quic_execution_profile_type_real_time);                                \
+       quic_execution_profile_real_time);                                     \
   /*-----------------------------------------*/                               \
   /*         msquic params starts            */                               \
   /*-----------------------------------------*/                               \
@@ -748,6 +748,7 @@ const QUIC_API_TABLE *MsQuic = NULL;
 BOOLEAN isRegistered = false;
 BOOLEAN isLibOpened = false;
 
+ErlNifResourceType *ctx_reg_t = NULL;
 ErlNifResourceType *ctx_listener_t = NULL;
 ErlNifResourceType *ctx_connection_t = NULL;
 ErlNifResourceType *ctx_stream_t = NULL;
@@ -897,6 +898,19 @@ resource_config_dealloc_callback(__unused_parm__ ErlNifEnv *env,
   TP_CB_3(end, (uintptr_t)obj, 0);
 }
 
+void
+resource_reg_dealloc_callback(__unused_parm__ ErlNifEnv *env, void *obj)
+{
+  TP_CB_3(start, (uintptr_t)obj, 0);
+  QuicerRegistrationCTX *reg_ctx = (QuicerRegistrationCTX *)obj;
+  deinit_r_ctx(reg_ctx);
+  if (reg_ctx->Registration)
+    {
+      MsQuic->RegistrationClose(reg_ctx->Registration);
+    }
+  TP_CB_3(end, (uintptr_t)obj, 0);
+}
+
 /*
 ** on_load is called when the NIF library is loaded and no previously loaded
 *library exists for this module.
@@ -934,6 +948,15 @@ on_load(ErlNifEnv *env,
   ErlNifResourceTypeInit configInit = {
     .dtor = resource_config_dealloc_callback, .down = NULL, .stop = NULL
   };
+
+  ErlNifResourceTypeInit regInit
+      = { .dtor = resource_reg_dealloc_callback, .down = NULL, .stop = NULL };
+
+  ctx_reg_t = enif_open_resource_type_x(env,
+                                        "registration_context_resource",
+                                        &regInit, // init callbacks
+                                        flags,
+                                        NULL);
 
   ctx_config_t = enif_open_resource_type_x(env,
                                            "config_context_resource",
@@ -1057,6 +1080,9 @@ closeLib(__unused_parm__ ErlNifEnv *env,
   return ATOM_OK;
 }
 
+/*
+** For global registration only
+*/
 static ERL_NIF_TERM
 registration(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -1418,6 +1444,9 @@ static ErlNifFunc nif_funcs[] = {
   { "reg_open", 0, registration, 0 },
   { "reg_open", 1, registration, 0 },
   { "reg_close", 0, deregistration, 0 },
+  { "new_registration", 2, new_registration2, 0},
+  { "shutdown_registration", 1, shutdown_registration_x, 0},
+  { "shutdown_registration", 3, shutdown_registration_x, 0},
   { "listen", 2, listen2, 0},
   { "start_listener", 3, start_listener3, 0},
   { "stop_listener", 1, stop_listener1, 0},

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1447,6 +1447,7 @@ static ErlNifFunc nif_funcs[] = {
   { "new_registration", 2, new_registration2, 0},
   { "shutdown_registration", 1, shutdown_registration_x, 0},
   { "shutdown_registration", 3, shutdown_registration_x, 0},
+  { "get_registration_name", 1, get_registration_name1, 0},
   { "listen", 2, listen2, 0},
   { "start_listener", 3, start_listener3, 0},
   { "stop_listener", 1, stop_listener1, 0},

--- a/c_src/quicer_nif.h
+++ b/c_src/quicer_nif.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "quicer_dgram.h"
 #include "quicer_eterms.h"
 #include "quicer_queue.h"
+#include "quicer_reg.h"
 #include "quicer_stream.h"
 #include "quicer_tp.h"
 
@@ -44,6 +45,7 @@ extern const QUIC_API_TABLE *MsQuic;
 extern QUIC_REGISTRATION_CONFIG GRegConfig;
 
 // Context Types
+extern ErlNifResourceType *ctx_reg_t;
 extern ErlNifResourceType *ctx_listener_t;
 extern ErlNifResourceType *ctx_connection_t;
 extern ErlNifResourceType *ctx_stream_t;

--- a/c_src/quicer_reg.c
+++ b/c_src/quicer_reg.c
@@ -1,0 +1,120 @@
+/*--------------------------------------------------------------------
+Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-------------------------------------------------------------------*/
+#include "quicer_reg.h"
+#include "quicer_nif.h"
+
+ERL_NIF_TERM
+new_registration2(ErlNifEnv *env,
+                  __unused_parm__ int argc,
+                  const ERL_NIF_TERM argv[])
+{
+  QUIC_STATUS status = QUIC_STATUS_SUCCESS;
+  ERL_NIF_TERM ename = argv[0];
+  QUIC_REGISTRATION_CONFIG RegConfig
+      = { NULL, QUIC_EXECUTION_PROFILE_LOW_LATENCY };
+
+  TP_NIF_3(start, 0, status);
+  if (argc == 2)
+    {
+      ERL_NIF_TERM eprofile = argv[1];
+      if (IS_SAME_TERM(eprofile, ATOM_QUIC_EXECUTION_PROFILE_LOW_LATENCY))
+        {
+          RegConfig.ExecutionProfile = QUIC_EXECUTION_PROFILE_LOW_LATENCY;
+        }
+      else if (IS_SAME_TERM(eprofile,
+                            ATOM_QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT))
+        {
+          RegConfig.ExecutionProfile
+              = QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT;
+        }
+      else if (IS_SAME_TERM(eprofile,
+                            ATOM_QUIC_EXECUTION_PROFILE_TYPE_SCAVENGER))
+        {
+          RegConfig.ExecutionProfile = QUIC_EXECUTION_PROFILE_TYPE_SCAVENGER;
+        }
+      else if (IS_SAME_TERM(eprofile,
+                            ATOM_QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME))
+        {
+          RegConfig.ExecutionProfile = QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME;
+        }
+      else
+        {
+          return ERROR_TUPLE_2(ATOM_BADARG);
+        }
+    }
+
+  QuicerRegistrationCTX *r_ctx = init_r_ctx();
+  if (!r_ctx)
+    {
+      ERROR_TUPLE_2(ATOM_ERROR_NOT_ENOUGH_MEMORY);
+    }
+  // Open Registration
+  if (QUIC_FAILED(
+          status = MsQuic->RegistrationOpen(&RegConfig, &r_ctx->Registration)))
+    {
+      // unlikely
+      TP_NIF_3(fail, 0, status);
+      deinit_r_ctx(r_ctx);
+      destroy_r_ctx(r_ctx);
+      return ERROR_TUPLE_2(ATOM_STATUS(status));
+    }
+  TP_NIF_3(success, 0, status);
+  return SUCCESS(enif_make_resource(env, r_ctx));
+}
+
+ERL_NIF_TERM
+shutdown_registration_x(ErlNifEnv *env, int argc, const ERL_NIF_TERM *argv)
+{
+  QuicerRegistrationCTX *r_ctx = NULL;
+  ErlNifUInt64 error_code = 0;
+  BOOLEAN silent = FALSE;
+  ERL_NIF_TERM ectx = argv[0];
+  if (!enif_get_resource(env, ectx, ctx_reg_t, (void **)&r_ctx))
+    {
+      return ERROR_TUPLE_2(ATOM_BADARG);
+    }
+
+  if (argc == 3)
+    {
+      ERL_NIF_TERM esilent = argv[1];
+      if (IS_SAME_TERM(ATOM_TRUE, esilent))
+        {
+          silent = TRUE;
+        }
+      else if (IS_SAME_TERM(ATOM_FALSE, esilent))
+        {
+          silent = FALSE;
+        }
+      else
+        {
+          return ERROR_TUPLE_2(ATOM_BADARG);
+        }
+
+      if (!enif_get_uint64(env, argv[2], &error_code))
+        {
+          return ERROR_TUPLE_2(ATOM_BADARG);
+        }
+    }
+
+  if (r_ctx->Registration && !r_ctx->is_released)
+    {
+      // void return, trigger callback, no blocking
+      MsQuic->RegistrationShutdown(r_ctx->Registration, silent, error_code);
+      destroy_r_ctx(r_ctx);
+    }
+
+  return ATOM_OK;
+}

--- a/c_src/quicer_reg.c
+++ b/c_src/quicer_reg.c
@@ -61,6 +61,15 @@ new_registration2(ErlNifEnv *env,
     {
       ERROR_TUPLE_2(ATOM_ERROR_NOT_ENOUGH_MEMORY);
     }
+
+  if (0 >= enif_get_string(
+          env, ename, r_ctx->name, UINT8_MAX + 1, ERL_NIF_LATIN1))
+    {
+      deinit_r_ctx(r_ctx);
+      destroy_r_ctx(r_ctx);
+      ERROR_TUPLE_2(ATOM_BADARG);
+    }
+
   // Open Registration
   if (QUIC_FAILED(
           status = MsQuic->RegistrationOpen(&RegConfig, &r_ctx->Registration)))
@@ -117,4 +126,19 @@ shutdown_registration_x(ErlNifEnv *env, int argc, const ERL_NIF_TERM *argv)
     }
 
   return ATOM_OK;
+}
+
+ERL_NIF_TERM
+get_registration_name1(ErlNifEnv *env,
+                       __unused_parm__ int argc,
+                       const ERL_NIF_TERM argv[])
+{
+  QuicerRegistrationCTX *r_ctx = NULL;
+  ERL_NIF_TERM ectx = argv[0];
+  if (!enif_get_resource(env, ectx, ctx_reg_t, (void **)&r_ctx))
+    {
+      return ERROR_TUPLE_2(ATOM_BADARG);
+    }
+
+  return SUCCESS(enif_make_string(env, r_ctx->name, ERL_NIF_LATIN1));
 }

--- a/c_src/quicer_reg.h
+++ b/c_src/quicer_reg.h
@@ -23,4 +23,7 @@ new_registration2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM
 shutdown_registration_x(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
+ERL_NIF_TERM
+get_registration_name1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
 #endif // QUICER_REG_H_

--- a/c_src/quicer_reg.h
+++ b/c_src/quicer_reg.h
@@ -1,0 +1,26 @@
+/*--------------------------------------------------------------------
+Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-------------------------------------------------------------------*/
+#ifndef QUICER_REG_H_
+#define QUICER_REG_H_
+#include <erl_nif.h>
+
+ERL_NIF_TERM
+new_registration2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM
+shutdown_registration_x(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+#endif // QUICER_REG_H_

--- a/include/quicer_types.hrl
+++ b/include/quicer_types.hrl
@@ -71,6 +71,11 @@
         conf_handle()       |
         reg_handle().
 
+-type registration_profile() :: quic_execution_profile_low_latency |
+                                quic_execution_profile_max_throughput |
+                                quic_execution_profile_scavenger |
+                                quic_execution_profile_realtime.
+
 -type quic_handle_level() :: quic_tls | quic_configuration | false.
 
 -type listen_on() :: inet:port_number() | string().

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -24,6 +24,9 @@
 %% Library APIs
 -export([ open_lib/0
         , close_lib/0
+        , new_registration/2
+        , shutdown_registration/1
+        , shutdown_registration/3
         , reg_open/0
         , reg_open/1
         , reg_close/0
@@ -140,7 +143,25 @@ close_lib() ->
   quicer_nif:close_lib().
 
 
-%% @doc Registraion should be opened before calling traffic APIs.
+%% @doc Create a new registration.
+-spec new_registration(Name, Profile) ->
+        quicer_nif:new_registration(Name, Profile).
+new_registration(Name, Profile) ->
+  quicer_nif:new_registration(Name, Profile).
+
+%% @doc Shutdown a registration.
+-spec shutdown_registration(Handle) ->
+        quicer_nif:shutdown_registration(Handle).
+shutdown_registration(Handle) ->
+  quicer_nif:shutdown_registration(Handle).
+
+%% @doc Shutdown a registration with error code and silent flag.
+-spec shutdown_registration(Handle, IsSilent, ErrCode) ->
+        quicer_nif:shutdown_registration(Handle, IsSilent, ErrCode).
+shutdown_registration(Handle, IsSilent, ErrCode) ->
+  quicer_nif:shutdown_registration(Handle, IsSilent, ErrCode).
+
+%% @doc GRegistraion should be opened before calling traffic APIs.
 %%
 %% This is called automatically when quicer application starts with
 %% app env: `profile'

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -27,6 +27,7 @@
         , new_registration/2
         , shutdown_registration/1
         , shutdown_registration/3
+        , get_registration_name/1
         , reg_open/0
         , reg_open/1
         , reg_close/0
@@ -160,6 +161,12 @@ shutdown_registration(Handle) ->
         quicer_nif:shutdown_registration(Handle, IsSilent, ErrCode).
 shutdown_registration(Handle, IsSilent, ErrCode) ->
   quicer_nif:shutdown_registration(Handle, IsSilent, ErrCode).
+
+%% @doc get registration name
+-spec get_registration_name(Handle) ->
+        quicer_nif:get_registration_name(Handle).
+get_registration_name(Handle) ->
+  quicer_nif:get_registration_name(Handle).
 
 %% @doc GRegistraion should be opened before calling traffic APIs.
 %%

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -22,6 +22,7 @@
         , new_registration/2
         , shutdown_registration/1
         , shutdown_registration/3
+        , get_registration_name/1
         , listen/2
         , start_listener/3
         , stop_listener/1
@@ -124,6 +125,10 @@ shutdown_registration(_Handle) ->
 -spec shutdown_registration(reg_handle(), IsSilent::boolean(), ErrorCode::uint64())
                            -> ok | {error | badarg}.
 shutdown_registration(_Handle, _IsSilent, _ErrorCode) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+-spec get_registration_name(reg_handle()) -> {ok, string()} | {error, badarg}.
+get_registration_name(_Handle) ->
   erlang:nif_error(nif_library_not_loaded).
 
 -spec listen(listen_on(), listen_opts()) ->

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -19,6 +19,9 @@
         , reg_open/0
         , reg_open/1
         , reg_close/0
+        , new_registration/2
+        , shutdown_registration/1
+        , shutdown_registration/3
         , listen/2
         , start_listener/3
         , stop_listener/1
@@ -106,6 +109,21 @@ reg_open(_) ->
 
 -spec reg_close() -> ok.
 reg_close() ->
+  erlang:nif_error(nif_library_not_loaded).
+
+
+-spec new_registration(Name::string(), registration_profile()) ->
+          {ok, reg_handle()} | {error, atom_reason()}.
+new_registration(_Name, _Profile) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+-spec shutdown_registration(reg_handle()) -> ok | {error | badarg}.
+shutdown_registration(_Handle) ->
+  erlang:nif_error(nif_library_not_loaded).
+
+-spec shutdown_registration(reg_handle(), IsSilent::boolean(), ErrorCode::uint64())
+                           -> ok | {error | badarg}.
+shutdown_registration(_Handle, _IsSilent, _ErrorCode) ->
   erlang:nif_error(nif_library_not_loaded).
 
 -spec listen(listen_on(), listen_opts()) ->

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -334,11 +334,11 @@ tc_lib_registration_1(_Config) ->
   {error, badarg} = quicer:reg_open(foo),
   ok = quicer:reg_open(quic_execution_profile_low_latency),
   ok = quicer:reg_close(),
-  ok = quicer:reg_open(quic_execution_profile_type_real_time),
+  ok = quicer:reg_open(quic_execution_profile_real_time),
   ok = quicer:reg_close(),
-  ok = quicer:reg_open(quic_execution_profile_type_max_throughput),
+  ok = quicer:reg_open(quic_execution_profile_max_throughput),
   ok = quicer:reg_close(),
-  ok = quicer:reg_open(quic_execution_profile_type_scavenger),
+  ok = quicer:reg_open(quic_execution_profile_scavenger),
   ok = quicer:reg_close().
 
 tc_open_listener_neg_1(Config) ->

--- a/test/quicer_reg_SUITE.erl
+++ b/test/quicer_reg_SUITE.erl
@@ -121,7 +121,6 @@ all() ->
          nomatch =/= string:prefix(atom_to_list(F), "tc_")
     ].
 
-
 %%--------------------------------------------------------------------
 %% @spec TestCase() -> Info
 %% Info = [tuple()]
@@ -142,7 +141,8 @@ all() ->
 tc_new_reg(_Config) ->
     Name = atom_to_list(?FUNCTION_NAME),
     Profile = quic_execution_profile_low_latency,
-    {ok, _Reg} = quicer:new_registration(Name, Profile),
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    quicer:shutdown_registration(Reg),
     ok.
 
 tc_shutdown_reg_1(_Config) ->
@@ -182,3 +182,11 @@ tc_shutdown_with_reason(_Config) ->
     Profile = quic_execution_profile_low_latency,
     {ok, Reg} = quicer:new_registration(Name, Profile),
     ok = quicer:shutdown_registration(Reg, false, 123).
+
+tc_get_reg_name(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    ?assertEqual({ok, Name}, quicer:get_registration_name(Reg)),
+    ok = quicer:shutdown_registration(Reg),
+    ?assertEqual({ok, Name}, quicer:get_registration_name(Reg)).

--- a/test/quicer_reg_SUITE.erl
+++ b/test/quicer_reg_SUITE.erl
@@ -1,0 +1,184 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(quicer_reg_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+%%--------------------------------------------------------------------
+%% @spec suite() -> Info
+%% Info = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+suite() ->
+    [{timetrap,{seconds,30}}].
+
+%%--------------------------------------------------------------------
+%% @spec init_per_suite(Config0) ->
+%%     Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% @spec end_per_suite(Config0) -> term() | {save_config,Config1}
+%% Config0 = Config1 = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @spec init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+init_per_group(_GroupName, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% @spec end_per_group(GroupName, Config0) ->
+%%               term() | {save_config,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+end_per_group(_GroupName, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @spec init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% @spec end_per_testcase(TestCase, Config0) ->
+%%               term() | {save_config,Config1} | {fail,Reason}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @spec groups() -> [Group]
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%% Shuffle = shuffle | {shuffle,{integer(),integer(),integer()}}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%% N = integer() | forever
+%% @end
+%%--------------------------------------------------------------------
+groups() ->
+    [].
+
+%%--------------------------------------------------------------------
+%% @spec all() -> GroupsAndTestCases | {skip,Reason}
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%% TestCase = atom()
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [ F
+      || {F, 1} <- ?MODULE:module_info(exports),
+         nomatch =/= string:prefix(atom_to_list(F), "tc_")
+    ].
+
+
+%%--------------------------------------------------------------------
+%% @spec TestCase() -> Info
+%% Info = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+%% my_test_case() ->
+%%     [].
+
+%%--------------------------------------------------------------------
+%% @spec TestCase(Config0) ->
+%%               ok | exit() | {skip,Reason} | {comment,Comment} |
+%%               {save_config,Config1} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% Comment = term()
+%% @end
+%%--------------------------------------------------------------------
+tc_new_reg(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, _Reg} = quicer:new_registration(Name, Profile),
+    ok.
+
+tc_shutdown_reg_1(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    ok = quicer:shutdown_registration(Reg),
+    ok.
+
+tc_shutdown_1_abnormal(_Config) ->
+    ?assertEqual({error, badarg}, quicer:shutdown_registration(erlang:make_ref())),
+    ?assertEqual({error, badarg}, quicer:shutdown_registration(1)).
+
+tc_shutdown_3_abnormal(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    ?assertEqual({error, badarg}, quicer:shutdown_registration(Reg, 1, 2)),
+    ?assertEqual({error, badarg}, quicer:shutdown_registration(Reg, 1, foo)),
+    ?assertEqual({error, badarg}, quicer:shutdown_registration(Reg, true, -1)).
+
+tc_shutdown_ok(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    ok = quicer:shutdown_registration(Reg).
+
+tc_shutdown_twice(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    ok = quicer:shutdown_registration(Reg),
+    ok = quicer:shutdown_registration(Reg).
+
+tc_shutdown_with_reason(_Config) ->
+    Name = atom_to_list(?FUNCTION_NAME),
+    Profile = quic_execution_profile_low_latency,
+    {ok, Reg} = quicer:new_registration(Name, Profile),
+    ok = quicer:shutdown_registration(Reg, false, 123).

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -1040,13 +1040,7 @@ tc_conn_no_gc(Config) ->
                                   5000, 1000),
                  %% Give it time for gc that should not happen on var 'Conn', could be the source of flakiness.
                  %% We are rather testing the OTP behavior here but proves our understandings are correct.
-                 %% OTP GC callback, should not happen
-                 timeout = ?block_until(#{ ?snk_kind := debug
-                                         , context := "callback"
-                                         , function := "resource_conn_dealloc_callback"
-                                         , resource_id := CRid
-                                         , tag := "end"},
-                                        5000, 1000),
+                 timer:sleep(5000),
                  {ok, CRid, SRid, Conn}
 
                end,
@@ -1147,23 +1141,7 @@ tc_conn_no_gc_2(Config) ->
                  %% But the resource dealloc callback should not be called since
                  %% we still have a ref in current process with Var: `ClientConn'
                  %% We are rather testing the OTP behavior here but proves our understandings are correct.
-                 Block = ?block_until(#{ ?snk_kind := debug
-                                       , context := "callback"
-                                       , function := "resource_conn_dealloc_callback"
-                                       , resource_id := CRid
-                                       , tag := "end"},
-                                      5000, 1000),
-                 case Block of
-                   timeout -> ok;
-                   {ok, #{ resource_id := CRid }} ->
-                     %% Don't fail the testcase here, we need the traces in post run
-                     ct:pal("!!!Error!!!: Rid: ~p of ~p should not be released~n"
-                            "Check snb traces for more",
-                            [CRid, ClientConn]);
-                   {ok, #{ resource_id := _OtherRid }} ->
-                     ok
-                 end,
-                 timer:sleep(1000),
+                 timer:sleep(5000),
                  %% We can get segfault here if it is use-after-free
                  quicer:getstat(ClientConn, [send_cnt, recv_oct, send_pend]),
                  {ok, CRid, SRid, ClientConn} %% Ensure we hold the ref here


### PR DESCRIPTION
msquic registration is an abstraction of execution env (threads)

Currently, all quicer resources use one global registration. 

This PR add multi-registration support for mapping msquic registration to quicer.

There will be follow-up PRS to

1. server: create listener under certain registration 
2. client: create new connection under certain registraion 
3. global registraion list that keeps track of the registration used by quicer. 



