### PR TITLE
Set cacertfile in tls ctx

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -42,6 +42,21 @@ jobs:
         git-branch: ${{ github.ref_name }}
         git-commit: ${{ github.sha }}
 
+    - name: Run cover with feature switches
+      run: |
+        sudo apt-get install lcov
+        export QUICER_USE_TRUSTED_STORE=1
+        make cover
+
+    - name: Coveralls C
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: run-c-lcov-feature
+        parallel: true
+        git-branch: ${{ github.ref_name }}
+        git-commit: ${{ github.sha }}
+
     - name: Coveralls Erl
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,11 @@ if (DEFINED ENV{QUICER_USE_SNK})
   add_compile_options(-DQUICER_USE_SNK)
 endif()
 
+if (DEFINED ENV{QUICER_USE_TRUSTED_STORE})
+  message(STATUS "Enable shared trusted store")
+  add_compile_options(-DQUICER_USE_TRUSTED_STORE)
+endif()
+
 if (DEFINED ENV{QUICER_USE_SANITIZERS})
   set(QUIC_ENABLE_SANITIZERS "ON")
   add_compile_options(-O1 -fno-omit-frame-pointer -fsanitize=address,leak,undefined)

--- a/c_src/quicer_connection.c
+++ b/c_src/quicer_connection.c
@@ -742,8 +742,8 @@ async_connect3(ErlNifEnv *env,
       goto Error;
     }
 
-    // parse opt cacertfile
 #ifdef QUICER_USE_TRUSTED_STORE
+  // parse opt cacertfile
   char *cacertfile = NULL;
   if (!parse_cacertfile_option(env, eoptions, &cacertfile))
     {
@@ -762,14 +762,6 @@ async_connect3(ErlNifEnv *env,
         }
       free(cacertfile);
       cacertfile = NULL;
-    }
-
-#else
-  if (!parse_cacertfile_option(env, eoptions, &c_ctx->cacertfile))
-    {
-      // TLS opt error not file content error
-      res = ERROR_TUPLE_2(ATOM_CACERTFILE);
-      goto Error;
     }
 #endif // QUICER_USE_TRUSTED_STORE
 

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -67,7 +67,9 @@ init_l_ctx()
   l_ctx->acceptor_queue = AcceptorQueueNew();
   l_ctx->lock = enif_mutex_create("quicer:l_ctx");
   l_ctx->cacertfile = NULL;
+#if defined(QUICER_USE_TRUSTED_STORE)
   l_ctx->trusted_store = NULL;
+#endif
   l_ctx->is_closed = TRUE;
   l_ctx->allow_insecure = FALSE;
   l_ctx->r_ctx = NULL;
@@ -78,10 +80,12 @@ init_l_ctx()
 void
 deinit_l_ctx(QuicerListenerCTX *l_ctx)
 {
+#if defined(QUICER_USE_TRUSTED_STORE)
   if (l_ctx->trusted_store)
     {
       X509_STORE_free(l_ctx->trusted_store);
     }
+#endif // QUICER_USE_TRUSTED_STORE
   AcceptorQueueDestroy(l_ctx->acceptor_queue);
   if (l_ctx->config_resource)
     {
@@ -145,7 +149,9 @@ init_c_ctx()
   c_ctx->acceptor_queue = AcceptorQueueNew();
   c_ctx->Connection = NULL;
   c_ctx->lock = enif_mutex_create("quicer:c_ctx");
+#if defined(QUICER_USE_TRUSTED_STORE)
   c_ctx->trusted = NULL;
+#endif // QUICER_USE_TRUSTED_STORE
   c_ctx->TlsSecrets = NULL;
   c_ctx->ResumptionTicket = NULL;
   c_ctx->event_mask = 0;
@@ -161,11 +167,13 @@ void
 deinit_c_ctx(QuicerConnCTX *c_ctx)
 {
   enif_free_env(c_ctx->env);
+#if defined(QUICER_USE_TRUSTED_STORE)
   if (c_ctx->trusted != NULL)
     {
       X509_STORE_free(c_ctx->trusted);
       c_ctx->trusted = NULL;
     }
+#endif // QUICER_USE_TRUSTED_STORE
   if (c_ctx->config_resource)
     {
       enif_release_resource(c_ctx->config_resource);
@@ -182,14 +190,15 @@ deinit_c_ctx(QuicerConnCTX *c_ctx)
 void
 destroy_c_ctx(QuicerConnCTX *c_ctx)
 {
-  // Since enif_release_resource is async call,
-  // we should demon the owner now!
+// Since enif_release_resource is async call,
+// we should demon the owner now!
+#if defined(QUICER_USE_TRUSTED_STORE)
   if (c_ctx->trusted != NULL)
     {
       X509_STORE_free(c_ctx->trusted);
       c_ctx->trusted = NULL;
     }
-
+#endif // QUICER_USE_TRUSTED_STORE
   QuicerRegistrationCTX *r_ctx;
   if (c_ctx->r_ctx)
     {

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -97,9 +97,7 @@ typedef struct QuicerConnCTX
   ErlNifMutex *lock;
 #if defined(QUICER_USE_TRUSTED_STORE)
   X509_STORE *trusted;
-#else
-  char *cacertfile;
-#endif // !QUICER_USE_TRUSTED_STORE
+#endif // QUICER_USE_TRUSTED_STORE
   QUIC_TLS_SECRETS *TlsSecrets;
   QUIC_BUFFER *ResumptionTicket;
   // Connection handle closed flag

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -66,7 +66,9 @@ typedef struct QuicerListenerCTX
   ErlNifEnv *env;
   ErlNifMutex *lock;
   char *cacertfile;
+#if defined(QUICER_USE_TRUSTED_STORE)
   X509_STORE *trusted_store;
+#endif
   // Listener handle closed flag
   // false means the handle is invalid
   BOOLEAN is_closed;
@@ -93,11 +95,15 @@ typedef struct QuicerConnCTX
   ErlNifMonitor owner_mon;
   ErlNifEnv *env;
   ErlNifMutex *lock;
+#if defined(QUICER_USE_TRUSTED_STORE)
   X509_STORE *trusted;
-  // Connection handle closed flag
-  // false means the handle is invalid
+#else
+  char *cacertfile;
+#endif // !QUICER_USE_TRUSTED_STORE
   QUIC_TLS_SECRETS *TlsSecrets;
   QUIC_BUFFER *ResumptionTicket;
+  // Connection handle closed flag
+  // false means the handle is invalid
   BOOLEAN is_closed;
   // track lifetime of Connection handle
   CXPLAT_REF_COUNT ref_count;

--- a/c_src/quicer_listener.c
+++ b/c_src/quicer_listener.c
@@ -337,6 +337,11 @@ listen2(ErlNifEnv *env, __unused_parm__ int argc, const ERL_NIF_TERM argv[])
 #else
       CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE;
       CredConfig.CaCertificateFile = cacertfile;
+#if defined(__APPLE__)
+      // This seems only needed for macOS
+      CredConfig.Flags
+          |= QUIC_CREDENTIAL_FLAG_USE_TLS_BUILTIN_CERTIFICATE_VALIDATION;
+#endif // __APPLE__
 #endif // QUICER_USE_TRUSTED_STORE
     }
   else

--- a/c_src/quicer_listener.c
+++ b/c_src/quicer_listener.c
@@ -59,12 +59,13 @@ ServerListenerCallback(__unused_parm__ HQUIC Listener,
       c_ctx->Connection = Event->NEW_CONNECTION.Connection;
       CxPlatRefInitialize(&(c_ctx->ref_count));
 
+#if defined(QUICER_USE_TRUSTED_STORE)
       if (l_ctx->trusted_store)
         {
           X509_STORE_up_ref(l_ctx->trusted_store);
           c_ctx->trusted = l_ctx->trusted_store;
         }
-
+#endif // QUICER_ENABLE_DEBUG_MSG
       assert(l_ctx->config_resource);
       // Keep resource for c_ctx
       enif_keep_resource(l_ctx->config_resource);
@@ -324,16 +325,26 @@ listen2(ErlNifEnv *env, __unused_parm__ int argc, const ERL_NIF_TERM argv[])
       // in cacertfile
       // @see QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED
       CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED;
-      CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
 
+#if defined(QUICER_USE_TRUSTED_STORE)
+      CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
+      l_ctx->cacertfile = cacertfile;
       if (!build_trustedstore(l_ctx->cacertfile, &l_ctx->trusted_store))
         {
           ret = ERROR_TUPLE_2(ATOM_CERT_ERROR);
           goto exit;
         }
+#else
+      CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE;
+      CredConfig.CaCertificateFile = cacertfile;
+#endif // QUICER_USE_TRUSTED_STORE
     }
   else
-    { // since we don't use cacertfile, free it
+    { // NO verify peer
+#if !defined(QUICER_USE_TRUSTED_STORE)
+      CredConfig.Flags |= QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
+#endif // QUICER_USE_TRUSTED_STORE
+      // since we don't use cacertfile, free it
       free(cacertfile);
       cacertfile = NULL;
     }

--- a/c_src/quicer_listener.c
+++ b/c_src/quicer_listener.c
@@ -65,7 +65,7 @@ ServerListenerCallback(__unused_parm__ HQUIC Listener,
           X509_STORE_up_ref(l_ctx->trusted_store);
           c_ctx->trusted = l_ctx->trusted_store;
         }
-#endif // QUICER_ENABLE_DEBUG_MSG
+#endif // QUICER_USE_TRUSTED_STORE
       assert(l_ctx->config_resource);
       // Keep resource for c_ctx
       enif_keep_resource(l_ctx->config_resource);

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -848,12 +848,13 @@ resource_listener_dealloc_callback(__unused_parm__ ErlNifEnv *env, void *obj)
       TP_CB_3(skip, (uintptr_t)l_ctx->Listener, 0);
     }
 
+#if defined(QUICER_USE_TRUSTED_STORE)
   if (l_ctx->cacertfile)
     {
       CXPLAT_FREE(l_ctx->cacertfile, QUICER_CACERTFILE);
       l_ctx->cacertfile = NULL;
     }
-
+#endif // QUICER_USE_TRUSTED_STORE
   deinit_l_ctx(l_ctx);
   // @TODO notify acceptors that the listener is closed
   TP_CB_3(end, (uintptr_t)l_ctx->Listener, 0);

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1356,6 +1356,9 @@ atom_status(ErlNifEnv *env, QUIC_STATUS status)
             case TLS1_AD_BAD_CERTIFICATE_HASH_VALUE:
               eterm = ATOM_QUIC_STATUS_BAD_CERTIFICATE;
               break;
+            case SSL_AD_DECRYPT_ERROR:
+              eterm = ATOM_QUIC_STATUS_HANDSHAKE_FAILURE;
+              break;
             default:
               eterm = enif_make_tuple2(
                   env, ATOM_UNKNOWN_TLS_STATUS_CODE, ETERM_UINT_64(tlserror));

--- a/c_src/quicer_tls.c
+++ b/c_src/quicer_tls.c
@@ -122,9 +122,17 @@ parse_verify_options(ErlNifEnv *env,
           ERL_NIF_TERM tmp;
           if (enif_get_map_value(env, options, ATOM_CACERTFILE, &tmp))
             {
+#if defined(QUICER_USE_TRUSTED_STORE)
               // cacertfile is set, use it for self validation.
               CredConfig->Flags
                   |= QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
+#else
+              // cacertfile is set, use it for OpenSSL validation.
+              CredConfig->Flags
+                  |= QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE;
+              CredConfig->CaCertificateFile = str_from_map(
+                  env, ATOM_CACERTFILE, &options, NULL, PATH_MAX + 1);
+#endif // QUICER_USE_TRUSTED_STORE
               CredConfig->Flags
                   |= QUIC_CREDENTIAL_FLAG_INDICATE_CERTIFICATE_RECEIVED;
             }
@@ -137,6 +145,7 @@ parse_verify_options(ErlNifEnv *env,
 
 /*
 ** Parse optional cacertfile option
+** @NOTE we alloc buffer for cacertfile, caller should free it
 */
 BOOLEAN
 parse_cacertfile_option(ErlNifEnv *env,
@@ -163,6 +172,7 @@ parse_cacertfile_option(ErlNifEnv *env,
   return TRUE;
 }
 
+#if defined(QUICER_USE_TRUSTED_STORE)
 BOOLEAN
 build_trustedstore(const char *cacertfile, X509_STORE **trusted_store)
 {
@@ -196,6 +206,7 @@ build_trustedstore(const char *cacertfile, X509_STORE **trusted_store)
   *trusted_store = store;
   return TRUE;
 }
+#endif // QUICER_USE_TRUSTED_STORE
 
 /*
  * Free certfile/certfileprotected of QUIC_CREDENTIAL_CONFIG

--- a/c_src/quicer_tls.c
+++ b/c_src/quicer_tls.c
@@ -208,10 +208,6 @@ build_trustedstore(const char *cacertfile, X509_STORE **trusted_store)
 }
 #endif // QUICER_USE_TRUSTED_STORE
 
-/*
- * Free certfile/certfileprotected of QUIC_CREDENTIAL_CONFIG
- *
- */
 void
 free_certificate(QUIC_CREDENTIAL_CONFIG *cc)
 {
@@ -235,6 +231,12 @@ free_certificate(QUIC_CREDENTIAL_CONFIG *cc)
       CxPlatFree(cc->CertificateFileProtected,
                  QUICER_CERTIFICATE_FILE_PROTECTED);
       cc->CertificateFileProtected = NULL;
+    }
+
+  if (cc->CaCertificateFile)
+    {
+      free((char *)cc->CaCertificateFile);
+      cc->CaCertificateFile = NULL;
     }
 }
 

--- a/test/quicer_connection_SUITE.erl
+++ b/test/quicer_connection_SUITE.erl
@@ -456,22 +456,30 @@ run_tc_conn_custom_ca_other(Config) ->
         end
     ),
     receive
-        listener_ready ->
-            {error, transport_down, #{
-                error := _ErrorCode,
-                status := handshake_failure
-            }} =
-                quicer:connect(
-                    "localhost",
-                    Port,
-                    default_conn_opts_verify(Config, "other-ca"),
-                    5000
-                ),
-            SPid ! done,
-            ensure_server_exit_normal(Ref)
+        listener_ready -> ok
     after 1000 ->
         ct:fail("timeout")
-    end.
+    end,
+
+    Res = quicer:connect(
+        "localhost",
+        Port,
+        default_conn_opts_verify(Config, "other-ca"),
+        5000
+    ),
+
+    ?assertMatch(
+        {error, transport_down, #{
+            error := _ErrorCode,
+            status := Status
+        }} when
+            Status == handshake_failure;
+            Status == bad_certificate;
+            Status == cert_untrusted_root,
+        Res
+    ),
+    SPid ! done,
+    ensure_server_exit_normal(Ref).
 
 tc_conn_client_cert(Config) ->
     {Pid, Ref} = spawn_monitor(fun() -> run_tc_conn_client_cert(Config) end),
@@ -646,8 +654,12 @@ run_tc_conn_client_bad_cert(Config) ->
                     end,
                     receive
                         {quic, transport_shutdown, _Ref, #{
-                            error := _ErrorCode, status := handshake_failure
-                        }} ->
+                            error := _ErrorCode, status := Status
+                        }} when
+                            Status == handshake_failure;
+                            Status == bad_certificate;
+                            Status == cert_untrusted_root
+                        ->
                             _ = flush([])
                     after 2000 ->
                         Other = flush([]),

--- a/test/quicer_connection_SUITE.erl
+++ b/test/quicer_connection_SUITE.erl
@@ -459,7 +459,7 @@ run_tc_conn_custom_ca_other(Config) ->
         listener_ready ->
             {error, transport_down, #{
                 error := _ErrorCode,
-                status := bad_certificate
+                status := handshake_failure
             }} =
                 quicer:connect(
                     "localhost",
@@ -646,7 +646,7 @@ run_tc_conn_client_bad_cert(Config) ->
                     end,
                     receive
                         {quic, transport_shutdown, _Ref, #{
-                            error := _ErrorCode, status := bad_certificate
+                            error := _ErrorCode, status := handshake_failure
                         }} ->
                             _ = flush([])
                     after 2000 ->

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -2336,10 +2336,8 @@ tc_listener_no_acceptor(Config) ->
                     #{
                         ?snk_kind := debug,
                         context := "callback",
-                        function := "resource_conn_dealloc_callback",
-                        %% assert Connection is unset
-                        resource_id := 0,
-                        tag := "start"
+                        function := "handle_connection_event_shutdown_complete",
+                        tag := "shutdown_complete"
                     },
                     Trace
                 )


### PR DESCRIPTION
fix #250 

This is new feature in msquic 2.2.

Before this change certificate (chain) validation was done in the callback (quicer) , now it is done in TLS.
- The old method is wrapped with `QUICER_USE_TRUSTED_STORE`
   We used to have trusted store cache in listener to speed up handshakes.
- more tweaks for macOS to make it work