### PR TITLE
fix mem leaks with invalid TLS configs

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -310,7 +310,8 @@ ClientLoadConfiguration(ErlNifEnv *env,
   // If Verify Peer...
   if (!parse_verify_options(env, *options, &CredConfig, FALSE, NULL))
     {
-      return ERROR_TUPLE_2(ATOM_VERIFY);
+      ret = ATOM_VERIFY;
+      goto done;
     }
 
   unsigned alpn_buffer_length = 0;

--- a/c_src/quicer_connection.c
+++ b/c_src/quicer_connection.c
@@ -772,7 +772,11 @@ async_connect3(ErlNifEnv *env,
   if (!IS_SAME_TERM(ATOM_OK, estatus))
     {
       res = ERROR_TUPLE_2(estatus);
-      goto Error;
+      if (!is_reuse_handle)
+        {
+          enif_release_resource(c_ctx);
+        }
+      return ERROR_TUPLE_2(ATOM_QUIC_REGISTRATION);
     }
 
   if (!is_reuse_handle)

--- a/c_src/quicer_listener.c
+++ b/c_src/quicer_listener.c
@@ -589,6 +589,7 @@ start_listener3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 
   if (!IS_SAME_TERM(ret, ATOM_OK))
     {
+      enif_release_resource(new_config_ctx);
       return ERROR_TUPLE_2(ret);
     }
 
@@ -600,6 +601,7 @@ start_listener3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   if (!l_ctx->Listener)
     {
       ret = ERROR_TUPLE_2(ATOM_CLOSED);
+      enif_release_resource(new_config_ctx);
       goto exit;
     }
 


### PR DESCRIPTION
Fix mem leaks detected by proper tests.
They are all negative cases when invalid tls configs are failed to set but some object like intermediate string (from Erlang term to string)  is not released.