### PR TITLE
buffer stream signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,8 @@ set(SOURCES
   c_src/quicer_config.h
   c_src/quicer_queue.c
   c_src/quicer_queue.h
+  c_src/quicer_owner_queue.c
+  c_src/quicer_owner_queue.h
   c_src/quicer_ctx.c
   c_src/quicer_ctx.h
   c_src/quicer_listener.c

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -270,6 +270,7 @@ init_s_ctx()
   s_ctx->is_recv_pending = FALSE;
   s_ctx->is_closed = TRUE; // init
   s_ctx->event_mask = 0;
+  s_ctx->sig_queue = NULL;
   return s_ctx;
 }
 

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define __QUICER_CTX_H_
 
 #include "quicer_nif.h"
+#include "quicer_owner_queue.h"
 #include "quicer_queue.h"
 #include <msquichelper.h>
 #include <openssl/x509.h>
@@ -137,6 +138,8 @@ typedef struct QuicerStreamCTX
   // Track lifetime of Stream handle
   CXPLAT_REF_COUNT ref_count;
   uint32_t event_mask;
+  // for ownership handoff
+  OWNER_SIGNAL_QUEUE *sig_queue;
   void *reserved1;
   void *reserved2;
   void *reserved3;

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1486,10 +1486,11 @@ stream_controlling_process(ErlNifEnv *env,
     {
       // rollback, must success
       enif_self(env, &s_ctx->owner->Pid);
+      flush_sig_buffer(env, s_ctx);
       enif_monitor_process(env, s_ctx, caller, &s_ctx->owner_mon);
       return ERROR_TUPLE_2(ATOM_OWNER_DEAD);
     }
-
+  flush_sig_buffer(env, s_ctx);
   TP_NIF_3(exit, (uintptr_t)s_ctx->Stream, (uintptr_t)&s_ctx->owner->Pid);
   return ATOM_OK;
 }
@@ -1575,6 +1576,8 @@ static ErlNifFunc nif_funcs[] = {
   { "setopt", 4, setopt4, 0},
   { "controlling_process", 2, controlling_process, 0},
   { "peercert", 1, peercert1, 0},
+  { "enable_sig_buffer", 1, enable_sig_buffer, 0},
+  { "flush_stream_buffered_sigs", 1, flush_stream_buffered_sigs, 0},
   /* for DEBUG */
   { "get_conn_rid", 1, get_conn_rid1, 1},
   { "get_stream_rid", 1, get_stream_rid1, 1},
@@ -1586,9 +1589,7 @@ static ErlNifFunc nif_funcs[] = {
   { "get_stream_owner", 1, get_stream_owner1, 0},
   { "get_listener_owner", 1, get_listener_owner1, 0},
   /* for testing */
-  {"buffer_sig", 3, buffer_sig, 0},
-  {"enable_sig_buffer", 1, enable_sig_buffer, 0},
-  {"flush_stream_buffered_sigs", 1, flush_stream_buffered_sigs, 0}
+  { "mock_buffer_sig", 3, mock_buffer_sig, 0}
   // clang-format on
 };
 

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1584,7 +1584,11 @@ static ErlNifFunc nif_funcs[] = {
   { "get_connections", 1, get_connectionsX, 0},
   { "get_conn_owner", 1, get_conn_owner1, 0},
   { "get_stream_owner", 1, get_stream_owner1, 0},
-  { "get_listener_owner", 1, get_listener_owner1, 0}
+  { "get_listener_owner", 1, get_listener_owner1, 0},
+  /* for testing */
+  {"buffer_sig", 3, buffer_sig, 0},
+  {"enable_sig_buffer", 1, enable_sig_buffer, 0},
+  {"flush_stream_buffered_sigs", 1, flush_stream_buffered_sigs, 0}
   // clang-format on
 };
 

--- a/c_src/quicer_owner_queue.c
+++ b/c_src/quicer_owner_queue.c
@@ -42,7 +42,6 @@ OWNER_SIGNAL *
 OwnerSignalAlloc()
 {
   OWNER_SIGNAL *sig = CxPlatAlloc(sizeof(OWNER_SIGNAL), QUICER_OWNER_SIGNAL);
-  sig->Link.Flink = NULL;
   return sig;
 }
 

--- a/c_src/quicer_owner_queue.c
+++ b/c_src/quicer_owner_queue.c
@@ -1,0 +1,76 @@
+/*--------------------------------------------------------------------
+Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-------------------------------------------------------------------*/
+#include "quicer_owner_queue.h"
+
+OWNER_SIGNAL_QUEUE *
+OwnerSignalQueueNew()
+{
+  OWNER_SIGNAL_QUEUE *sig
+      = CxPlatAlloc(sizeof(OWNER_SIGNAL_QUEUE), QUICER_OWNER_SIGNAL);
+  return sig;
+}
+
+void
+OwnerSignalQueueInit(OWNER_SIGNAL_QUEUE *queue)
+{
+  queue->env = enif_alloc_env();
+  CxPlatListInitializeHead(&queue->List);
+}
+
+void
+OwnerSignalQueueDestroy(OWNER_SIGNAL_QUEUE *queue)
+{
+  CXPLAT_DBG_ASSERT(CxPlatListIsEmpty(&queue->List));
+  enif_free_env(queue->env);
+  CxPlatFree(queue, QUICER_OWNER_SIGNAL);
+}
+
+OWNER_SIGNAL *
+OwnerSignalAlloc()
+{
+  OWNER_SIGNAL *sig = CxPlatAlloc(sizeof(OWNER_SIGNAL), QUICER_OWNER_SIGNAL);
+  sig->Link.Flink = NULL;
+  return sig;
+}
+
+void
+OwnerSignalFree(OWNER_SIGNAL *sig)
+{
+  CXPLAT_FREE(sig, QUICER_OWNER_SIGNAL);
+}
+
+void
+OwnerSignalEnqueue(_In_ OWNER_SIGNAL_QUEUE *queue, _In_ OWNER_SIGNAL *sig)
+{
+  CxPlatListInsertTail(&queue->List, &sig->Link);
+}
+
+OWNER_SIGNAL *
+OwnerSignalDequeue(_In_ OWNER_SIGNAL_QUEUE *queue)
+{
+  OWNER_SIGNAL *sig;
+  if (CxPlatListIsEmpty(&queue->List))
+    {
+      sig = NULL;
+    }
+  else
+    {
+      sig = CXPLAT_CONTAINING_RECORD(
+          CxPlatListRemoveHead(&queue->List), OWNER_SIGNAL, Link);
+    }
+
+  return sig;
+}

--- a/c_src/quicer_owner_queue.h
+++ b/c_src/quicer_owner_queue.h
@@ -1,0 +1,50 @@
+/*--------------------------------------------------------------------
+Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-------------------------------------------------------------------*/
+#ifndef QUICER_OWNER_QUEUE_H_
+#define QUICER_OWNER_QUEUE_H_
+
+#include <erl_nif.h>
+#include <quicer_internal.h>
+#include <msquic.h>
+#include <quic_platform.h>
+
+
+#define QUICER_OWNER_SIGNAL 'E0rQ' // 'Er0d'  QUICER_OWNER_SIGNAL
+
+// Owner Signal Queue
+typedef struct OWNER_SIGNAL_QUEUE
+{
+  ErlNifEnv *env;
+  CXPLAT_LIST_ENTRY List;
+} OWNER_SIGNAL_QUEUE;
+
+typedef struct OWNER_SIGNAL
+{
+  CXPLAT_LIST_ENTRY Link;
+  ERL_NIF_TERM msg;        // resides in `env` of OWNER_SIGNAL_QUEUE
+  ERL_NIF_TERM orig_owner; // owner when msg is generated
+} OWNER_SIGNAL;
+
+OWNER_SIGNAL_QUEUE *OwnerSignalQueueNew();
+OWNER_SIGNAL *OwnerSignalAlloc();
+void OwnerSignalQueueInit(OWNER_SIGNAL_QUEUE *queue);
+void OwnerSignalQueueDestroy(OWNER_SIGNAL_QUEUE *queue);
+void OwnerSignalFree(OWNER_SIGNAL *sig);
+void OwnerSignalEnqueue(_In_ OWNER_SIGNAL_QUEUE *queue,
+                        _In_ OWNER_SIGNAL *sig);
+OWNER_SIGNAL *OwnerSignalDequeue(_In_ OWNER_SIGNAL_QUEUE *queue);
+
+#endif // QUICER_OWNER_QUEUE_H_

--- a/c_src/quicer_owner_queue.h
+++ b/c_src/quicer_owner_queue.h
@@ -17,10 +17,12 @@ limitations under the License.
 #define QUICER_OWNER_QUEUE_H_
 
 #include <erl_nif.h>
+
+// clang-format off
 #include <quicer_internal.h>
 #include <msquic.h>
 #include <quic_platform.h>
-
+// clang-format on
 
 #define QUICER_OWNER_SIGNAL 'E0rQ' // 'Er0d'  QUICER_OWNER_SIGNAL
 

--- a/c_src/quicer_stream.h
+++ b/c_src/quicer_stream.h
@@ -18,10 +18,13 @@ limitations under the License.
 #define __QUICER_STREAM_H_
 
 #include "quicer_config.h"
+#include "quicer_ctx.h"
 #include "quicer_internal.h"
 #include "quicer_nif.h"
 
 #define UNSET_STREAMID 0xFFFFFFFFFFFFFFF
+
+struct QuicerStreamCTX;
 
 typedef enum QUICER_SEND_FLAGS
 {
@@ -68,7 +71,7 @@ ERL_NIF_TERM
 get_stream_owner1(ErlNifEnv *env, int args, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM
-buffer_sig(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+mock_buffer_sig(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM
 flush_stream_buffered_sigs(ErlNifEnv *env,
@@ -77,3 +80,7 @@ flush_stream_buffered_sigs(ErlNifEnv *env,
 
 ERL_NIF_TERM
 enable_sig_buffer(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+typedef struct QuicerStreamCTX QuicerStreamCTX;
+BOOLEAN
+flush_sig_buffer(ErlNifEnv *env, QuicerStreamCTX *s_ctx);

--- a/c_src/quicer_stream.h
+++ b/c_src/quicer_stream.h
@@ -66,3 +66,14 @@ get_stream_rid1(ErlNifEnv *env, int args, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM
 get_stream_owner1(ErlNifEnv *env, int args, const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM
+buffer_sig(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM
+flush_stream_buffered_sigs(ErlNifEnv *env,
+                           int argc,
+                           const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM
+enable_sig_buffer(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -62,7 +62,11 @@
     get_connections/1,
     get_conn_owner/1,
     get_stream_owner/1,
-    get_listener_owner/1
+    get_listener_owner/1,
+    buffer_sig/3,
+    %% @TODO move to API
+    flush_stream_buffered_sigs/1,
+    enable_sig_buffer/1
 ]).
 
 -export([abi_version/0]).
@@ -371,6 +375,19 @@ get_connections() ->
 
 -spec get_connections(reg_handle()) -> [connection_handle()] | {error, badarg}.
 get_connections(_RegHandle) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec enable_sig_buffer(stream_handle()) -> ok.
+enable_sig_buffer(_H) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec buffer_sig(stream_handle(), OrigOwner :: pid(), term()) ->
+    ok | {error, false | none | bad_pid | bad_arg}.
+buffer_sig(_StreamHandle, _OrigOwner, _Msg) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec flush_stream_buffered_sigs(stream_handle()) -> ok | {error, badarg | none}.
+flush_stream_buffered_sigs(_H) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% Internals

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -44,7 +44,9 @@
     getopt/3,
     setopt/4,
     controlling_process/2,
-    peercert/1
+    peercert/1,
+    enable_sig_buffer/1,
+    flush_stream_buffered_sigs/1
 ]).
 
 -export([
@@ -63,10 +65,7 @@
     get_conn_owner/1,
     get_stream_owner/1,
     get_listener_owner/1,
-    buffer_sig/3,
-    %% @TODO move to API
-    flush_stream_buffered_sigs/1,
-    enable_sig_buffer/1
+    mock_buffer_sig/3
 ]).
 
 -export([abi_version/0]).
@@ -377,17 +376,26 @@ get_connections() ->
 get_connections(_RegHandle) ->
     erlang:nif_error(nif_library_not_loaded).
 
+%% @doc enable signal buffering, used in stream handoff.
+%% * not exposed API.
 -spec enable_sig_buffer(stream_handle()) -> ok.
 enable_sig_buffer(_H) ->
     erlang:nif_error(nif_library_not_loaded).
 
--spec buffer_sig(stream_handle(), OrigOwner :: pid(), term()) ->
-    ok | {error, false | none | bad_pid | bad_arg}.
-buffer_sig(_StreamHandle, _OrigOwner, _Msg) ->
-    erlang:nif_error(nif_library_not_loaded).
-
+%% @doc flush buffered stream signals to the current owner
+%% * not exposed API.
+%% also @see quicer:controlling_process/2
+%% @end
 -spec flush_stream_buffered_sigs(stream_handle()) -> ok | {error, badarg | none}.
 flush_stream_buffered_sigs(_H) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+%% @doc mock buffer a signal in sig_buffer.
+%%      for testing sig_buffer
+%% @end
+-spec mock_buffer_sig(stream_handle(), OrigOwner :: pid(), term()) ->
+    ok | {error, false | none | bad_pid | bad_arg}.
+mock_buffer_sig(_StreamHandle, _OrigOwner, _Msg) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% Internals

--- a/test/prop_stream_sig_queue.erl
+++ b/test/prop_stream_sig_queue.erl
@@ -1,0 +1,110 @@
+-module(prop_stream_sig_queue).
+-include_lib("proper/include/proper.hrl").
+-include_lib("quicer/include/quicer_types.hrl").
+-include("prop_quic_types.hrl").
+
+%%%%%%%%%%%%%%%%%%
+%%% Properties %%%
+%%%%%%%%%%%%%%%%%%
+prop_buffer_sig_err_none() ->
+    ?FORALL(
+        {#prop_handle{handle = S}, Pid, Term},
+        {valid_stream(), pid(), term()},
+        begin
+            Res = quicer_nif:buffer_sig(S, Pid, Term),
+            Res == {error, none}
+        end
+    ).
+
+prop_enable_sig_queue() ->
+    ?FORALL(
+        #prop_handle{type = stream, handle = S, destructor = Destructor},
+        valid_stream(),
+        begin
+            ok = quicer:setopt(S, active, 100),
+            ok = quicer_nif:enable_sig_buffer(S),
+            Res = quicer:getopt(S, active),
+            Destructor(),
+            Res == {ok, false}
+        end
+    ).
+
+prop_buffer_sig_success() ->
+    ?FORALL(
+        {#prop_handle{handle = S, destructor = Destructor}, Pid, Term},
+        {valid_stream(), pid(), term()},
+        begin
+            ok = quicer_nif:enable_sig_buffer(S),
+            Res = quicer_nif:buffer_sig(S, Pid, Term),
+            Destructor(),
+            Res == ok
+        end
+    ).
+
+prop_flush_buffered_sig_no_owner_change() ->
+    ?FORALL(
+        {#prop_handle{handle = S, destructor = Destructor}, Pid, TermList},
+        {valid_stream(), pid(), list(term())},
+        begin
+            ok = quicer_nif:enable_sig_buffer(S),
+            Ref = erlang:make_ref(),
+            lists:foreach(
+                fun(Term) ->
+                    quicer_nif:buffer_sig(S, Pid, {Ref, Term})
+                end,
+                TermList
+            ),
+            ok = quicer_nif:flush_stream_buffered_sigs(S),
+            Destructor(),
+            Rcvd = receive_n(length(TermList), Ref),
+            Rcvd == TermList
+        end
+    ).
+
+prop_flush_buffered_sig_success() ->
+    ?FORALL(
+        {#prop_handle{handle = S, destructor = Destructor}, Pid, TermList},
+        {valid_stream(), pid(), list(integer())},
+        begin
+            ok = quicer_nif:enable_sig_buffer(S),
+            Ref = erlang:make_ref(),
+            lists:foreach(
+                fun(Term) ->
+                    ok = quicer_nif:buffer_sig(S, Pid, {Ref, Term})
+                end,
+                TermList
+            ),
+            ok = quicer:controlling_process(S, self()),
+            {ok, NewOwner} = quicer:get_stream_owner(S),
+            NewOwner = self(),
+            ok = quicer_nif:flush_stream_buffered_sigs(S),
+            Res = receive_n(length(TermList), Ref),
+            Destructor(),
+            Res == TermList
+        end
+    ).
+
+%%%%%%%%%%%%%%%
+%%% Helpers %%%
+%%%%%%%%%%%%%%%
+receive_n(N, Ref) ->
+    receive_n(N, Ref, []).
+receive_n(0, _Ref, Acc) ->
+    lists:reverse(Acc);
+receive_n(N, Ref, Acc) ->
+    receive
+        {Ref, X} ->
+            receive_n(N - 1, Ref, [X | Acc]);
+        {quic, _, _, _} = _Drop ->
+            receive_n(N, Ref, Acc)
+    after 1000 ->
+        {timeout, N}
+    end.
+
+%%%%%%%%%%%%%%%%%%
+%%% Generators %%%
+%%%%%%%%%%%%%%%%%%
+valid_stream() -> quicer_prop_gen:valid_stream_handle().
+
+pid() ->
+    quicer_prop_gen:pid().

--- a/test/prop_stream_sig_queue.erl
+++ b/test/prop_stream_sig_queue.erl
@@ -8,10 +8,11 @@
 %%%%%%%%%%%%%%%%%%
 prop_buffer_sig_err_none() ->
     ?FORALL(
-        {#prop_handle{handle = S}, Pid, Term},
+        {#prop_handle{handle = S, destructor = Destructor}, Pid, Term},
         {valid_stream(), pid(), term()},
         begin
             Res = quicer_nif:buffer_sig(S, Pid, Term),
+            Destructor(),
             Res == {error, none}
         end
     ).
@@ -97,7 +98,7 @@ receive_n(N, Ref, Acc) ->
             receive_n(N - 1, Ref, [X | Acc]);
         {quic, _, _, _} = _Drop ->
             receive_n(N, Ref, Acc)
-    after 1000 ->
+    after 500 ->
         {timeout, N}
     end.
 

--- a/test/prop_stream_sig_queue.erl
+++ b/test/prop_stream_sig_queue.erl
@@ -78,7 +78,8 @@ prop_flush_buffered_sig_success() ->
             ok = quicer:controlling_process(S, self()),
             {ok, NewOwner} = quicer:get_stream_owner(S),
             NewOwner = self(),
-            ok = quicer_nif:flush_stream_buffered_sigs(S),
+            %% assert already flushed by quicer:controlling_process/2
+            {error, none} = quicer_nif:flush_stream_buffered_sigs(S),
             Res = receive_n(length(TermList), Ref),
             Destructor(),
             Res == TermList

--- a/test/prop_stream_sig_queue.erl
+++ b/test/prop_stream_sig_queue.erl
@@ -11,7 +11,7 @@ prop_buffer_sig_err_none() ->
         {#prop_handle{handle = S, destructor = Destructor}, Pid, Term},
         {valid_stream(), pid(), term()},
         begin
-            Res = quicer_nif:buffer_sig(S, Pid, Term),
+            Res = quicer_nif:mock_buffer_sig(S, Pid, Term),
             Destructor(),
             Res == {error, none}
         end
@@ -36,7 +36,7 @@ prop_buffer_sig_success() ->
         {valid_stream(), pid(), term()},
         begin
             ok = quicer_nif:enable_sig_buffer(S),
-            Res = quicer_nif:buffer_sig(S, Pid, Term),
+            Res = quicer_nif:mock_buffer_sig(S, Pid, Term),
             Destructor(),
             Res == ok
         end
@@ -51,7 +51,7 @@ prop_flush_buffered_sig_no_owner_change() ->
             Ref = erlang:make_ref(),
             lists:foreach(
                 fun(Term) ->
-                    quicer_nif:buffer_sig(S, Pid, {Ref, Term})
+                    quicer_nif:mock_buffer_sig(S, Pid, {Ref, Term})
                 end,
                 TermList
             ),
@@ -71,7 +71,7 @@ prop_flush_buffered_sig_success() ->
             Ref = erlang:make_ref(),
             lists:foreach(
                 fun(Term) ->
-                    ok = quicer_nif:buffer_sig(S, Pid, {Ref, Term})
+                    ok = quicer_nif:mock_buffer_sig(S, Pid, {Ref, Term})
                 end,
                 TermList
             ),


### PR DESCRIPTION
QUIC stream data is ensured ordered and lossless during stream handoff from old owner process to the new owner process.

This PR makes QUIC stream signals also ordered so that old owner does not need to take care of the `inflight` messages during the handoff.

The new `quicer_owner_queue` things could be reused to later implement the sig queues for the quic connections.