### PR TITLE
perf: prefer inspect binary to avoid copy

### DIFF
--- a/c_src/quicer_stream.c
+++ b/c_src/quicer_stream.c
@@ -588,8 +588,8 @@ csend4(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   //
   // Allocates and builds the buffer to send over the stream.
   //
-  if (!(enif_inspect_iolist_as_binary(send_ctx->env, ebin, bin)
-        || enif_inspect_binary(send_ctx->env, ebin, bin))
+  if (!(enif_inspect_binary(send_ctx->env, ebin, bin)
+        || enif_inspect_iolist_as_binary(send_ctx->env, ebin, bin))
       || bin->size > UINT32_MAX)
     {
 
@@ -692,8 +692,8 @@ send3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     }
 
   ebin = enif_make_copy(send_ctx->env, ebin);
-  if (!(enif_inspect_iolist_as_binary(send_ctx->env, ebin, bin)
-        || enif_inspect_binary(send_ctx->env, ebin, bin))
+  if (!(enif_inspect_binary(send_ctx->env, ebin, bin)
+        || enif_inspect_iolist_as_binary(send_ctx->env, ebin, bin))
       || bin->size > UINT32_MAX)
     {
       res = ERROR_TUPLE_2(ATOM_BADARG);


### PR DESCRIPTION
prefer to inspect binary first because inspect binary as iolist alloc and copies the binary which has high memory footprint