### PR TITLE
ci(release): release macos links to sys libcrypto

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
         openssl:
           - openssl3
           - openssl
+          - sys
         os:
           - macos-14
           - macos-13


### PR DESCRIPTION
EMQX needs this prebuild as EMQX by default links to sys libcrypto