### PR TITLE
ci: switch workflows to recent Erlang/OTP 27

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
         with:
-          otp-version: 24.3.4
+          otp-version: '27'
 
       - name: Build cpp
         run: make build-nif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
-      - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: '27'
 

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-    - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+    - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
       with:
         otp-version: ${{ matrix.otp }}
         rebar3-version: ${{ matrix.rebar3 }}

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         otp:
-          - 25.3.2
+          - '27'
         rebar3:
-          - 3.20.0
+          - '3.23.0'
         build_type:
           - RelWithDebInfo
         logging:

--- a/.github/workflows/lux.yml
+++ b/.github/workflows/lux.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         otp:
-          - 25.3.2
-          - 26.2.1
+          - '26.2.1'
+          - '27.2'
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
@@ -17,7 +17,7 @@ jobs:
       - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
         with:
           otp-version: ${{ matrix.otp }}
-          rebar3-version: 3.23.0
+          rebar3-version: '3.23.0'
 
       - name: build lux
         run: |

--- a/.github/workflows/lux.yml
+++ b/.github/workflows/lux.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           submodules: recursive
-      - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: '3.23.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         clang-format-version: '13'
         check-path: 'c_src'
     - name: Prepare OTP and rebar3
-      uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+      uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
       with:
         otp-version: '27'
         rebar3-version: '3.23.0'
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           submodules: recursive
-      - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ matrix.rebar3 }}
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           submodules: recursive
-      - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ matrix.rebar3 }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Prepare OTP and rebar3
       uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
       with:
-        otp-version: 26
-        rebar3-version: 3.20.0
+        otp-version: '27'
+        rebar3-version: '3.23.0'
     - name: Run erlfmt for erlang code
       run: |
         rebar3 fmt -c
@@ -31,9 +31,9 @@ jobs:
       matrix:
         # https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
         otp:
-          - 26.2.5.3
+          - '27'
         rebar3:
-          - 3.23.0
+          - '3.23.0'
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
@@ -63,7 +63,9 @@ jobs:
           - macos-14
           - macos-15
         otp:
-          - 26
+          - '27'
+        rebar3:
+          - '3.23.0'
         openssl:
           - openssl3
           - openssl
@@ -91,7 +93,7 @@ jobs:
           QUICER_TLS_VER: ${{ matrix.openssl }}
         run: |
           export QUICER_TLS_VER
-          wget https://s3.amazonaws.com/rebar3/rebar3
+          wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3 }}/rebar3
           sudo mv rebar3 /usr/local/bin/ && sudo chmod +x /usr/local/bin/rebar3
           erl -eval 'erlang:display(erlang:system_info(system_version)),halt()'
           ulimit -c unlimited
@@ -126,15 +128,15 @@ jobs:
       matrix:
         # https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
         otp:
-          - 25.3.2.9
-          - 26.2.5.3
-          - 27.1
+          - '25.3.2.9'
+          - '26.2.5.3'
+          - '27.2'
         openssl:
           - openssl3
           - openssl
           - sys
         rebar3:
-          - 3.23.0
+          - '3.23.0'
         build_type:
           - RelWithDebInfo
           - Debug

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,14 +18,17 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - 26
+          - '26'
+          - '27'
+        rebar3:
+          - '3.23.0'
         openssl:
           - openssl3
           - openssl
           - sys
         os:
           - macos-14
-          - macos-13
+          - macos-15
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -51,7 +54,7 @@ jobs:
         env:
           QUICER_TLS_VER: ${{ matrix.openssl }}
         run: |
-          wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+          wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3 }}/rebar3
           sudo mv rebar3 /usr/local/bin/ && sudo chmod +x /usr/local/bin/rebar3
           erl -eval 'erlang:display(erlang:system_info(system_version)),halt()'
           export QUICER_TLS_VER
@@ -69,8 +72,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp:
-          - 26.2.5.2-1
+        erlang:
+          - otp: 26.2.5.2-3
+            builder: 5.4-4:1.15.7-26.2.5.2-3
+          - otp: 27.2-2
+            builder: 5.4-4:1.17.3-27.2-2
         openssl:
           - openssl3
           - openssl
@@ -110,18 +116,21 @@ jobs:
       - name: build release
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          IMAGE=ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
-          docker run -i --rm -v $(pwd):/wd --workdir /wd --platform=linux/${{ matrix.arch }} \
-          -e BUILD_RELEASE=1 -e QUICER_TLS_VER=${{ matrix.openssl }} \
-          $IMAGE bash -euc 'git config --global --add safe.directory /wd; \
-          grep -q "\"Amazon Linux 2\"" /etc/os-release && alternatives --set python /usr/bin/python2; \
-          which yum && yum install -y perl-IPC-Cmd; \
-          make'
+          docker run -i --rm -v $(pwd):/wd --workdir /wd \
+            --platform=linux/${{ matrix.arch }} \
+            -e BUILD_RELEASE=1 \
+            -e QUICER_TLS_VER=${{ matrix.openssl }} \
+            ghcr.io/emqx/emqx-builder/${{ matrix.erlang.builder }}-${{ matrix.os }} \
+              bash -euc '\
+                git config --global --add safe.directory /wd; \
+                grep -q "\"Amazon Linux 2\"" /etc/os-release && alternatives --set python /usr/bin/python2; \
+                which yum && yum install -y perl-IPC-Cmd; \
+                make'
 
       - uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: quicer-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.otp }}-${{ matrix.openssl }}
+          name: quicer-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.erlang.otp }}-${{ matrix.openssl }}
           path: |
             _packages/*.gz
             _packages/*.gz.sha256

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,11 +102,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: install rebar3
-        run: |
-          wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
-          cp ./rebar3 /usr/local/bin/rebar3
-
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,11 +7,15 @@ on:
         description: 'Ref to release'
         required: false
         default: ''
+      ref_name:
+        description: 'Tag to (re)release'
+        required: false
   push:
     tags:
       - "*"
     branches:
       - 'ci/**'
+
 jobs:
   mac:
     strategy:
@@ -50,7 +54,6 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: build release
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           QUICER_TLS_VER: ${{ matrix.openssl }}
         run: |
@@ -61,7 +64,6 @@ jobs:
           BUILD_RELEASE=1 make
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: quicer-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.openssl }}
           path: |
@@ -101,6 +103,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
 
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
@@ -109,7 +112,6 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: build release
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           docker run -i --rm -v $(pwd):/wd --workdir /wd \
             --platform=linux/${{ matrix.arch }} \
@@ -123,7 +125,6 @@ jobs:
                 make'
 
       - uses: actions/upload-artifact@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: quicer-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.erlang.otp }}-${{ matrix.openssl }}
           path: |
@@ -135,7 +136,7 @@ jobs:
     needs:
       - mac
       - emqx-linux
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event.inputs.ref_name || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -145,7 +146,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          name: quicer ${{ github.ref_name }} Released
+          name: quicer ${{ github.event.inputs.ref_name || github.ref_name }} Released
+          tag_name: ${{ github.event.inputs.ref_name || github.ref_name }}
           files: packages/*
           draft: true
           prerelease: false

--- a/test/quicer_test_lib.erl
+++ b/test/quicer_test_lib.erl
@@ -402,7 +402,13 @@ report_active_connections() ->
     report_active_connections(fun ct:comment/2).
 report_active_connections(LogFun) ->
     erlang:garbage_collect(),
-    {ok, Cnts} = quicer:perf_counters(),
+    case quicer:perf_counters() of
+        {ok, Cnts} ->
+            ok;
+        {error, not_found} ->
+            %% Library is likely not loaded.
+            Cnts = [{strm_active, 0}, {conn_active, 0}]
+    end,
     ActiveStrms = proplists:get_value(strm_active, Cnts),
     ActiveConns = proplists:get_value(conn_active, Cnts),
     0 =/= (ActiveStrms + ActiveConns) andalso


### PR DESCRIPTION
Another notable change to the release workflow is an ability to re-release existing tags through the _workflow dispatch_ trigger. This could be useful to populate existing releases with binaries built for recent Erlang/OTP versions (in this case Erlang/OTP 27).

See individual commits for details.