### PR TITLE
Guard glibc-specific functions using __GLIBC__ define

### DIFF
--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -17,11 +17,12 @@ limitations under the License.
 #include "quicer_nif.h"
 
 #include <dlfcn.h>
+#include <features.h>
 
 #include "quicer_listener.h"
 #include "quicer_vsn.h"
 
-#if defined(__linux__)
+#if defined(__GLIBC__)
 #include <malloc.h>
 #endif
 
@@ -1701,7 +1702,7 @@ make_event(ErlNifEnv *env,
                           prop);      // 4th element, event props :: any()) //
 }
 
-#if defined(__linux__)
+#if defined(__GLIBC__)
 ERL_NIF_TERM
 do_malloc_trim(__unused_parm__ ErlNifEnv *env,
                __unused_parm__ int argc,
@@ -1779,7 +1780,7 @@ static ErlNifFunc nif_funcs[] = {
   { "copy_stream_handle", 1, copy_stream_handle, 0},
   /* for testing */
   { "mock_buffer_sig", 3, mock_buffer_sig, 0},
-#if defined(__linux__)
+#if defined(__GLIBC__)
   { "malloc_trim", 0, do_malloc_trim, 0},
   { "malloc_stats", 0, do_malloc_stats, 0},
 #endif


### PR DESCRIPTION
Hi! I've been compiling and running quicer on alpine, but recent versions no longer compile. I'm a little bit out of my depth here but it seems to be because alpine uses musl instead of glibc and is missing the malloc_trim and malloc_stats functions. These are already protected by the __linux__ define so I'm wondering if you would consider changing that to __GLIBC__ instead.