### PR TITLE
build: cache patches

### DIFF
--- a/get-msquic.sh
+++ b/get-msquic.sh
@@ -10,7 +10,12 @@ do_patch()
 {
     patch_source="$1"
     patch_file="${patch_dir}/$(basename ${patch_source})"
-    curl -f -L -o "${patch_file}" "$patch_source"
+
+    if [ -f "${patch_file}" ]; then
+        echo "Patch ${patch_file} already exists, skipping download"
+    else
+        curl -f -L -o "${patch_file}" "$patch_source"
+    fi
     if patch -p1 -f --dry-run -s < "${patch_file}" 2>/dev/null; then
         patch -p1 < "${patch_file}"
     else
@@ -42,7 +47,9 @@ patch_2_3_8()
     local patch_2="https://github.com/microsoft/msquic/commit/e0201eb4e007e7524aef007be67f2281f949f102.patch"
     local patch_3="https://github.com/microsoft/msquic/commit/b16a14a72e8c74407ee4a079a1f57efe0246f739.patch"
     local patch_4="https://github.com/microsoft/msquic/pull/4717/commits/9261dacc1dd9a67f6fa8d5fbe663082508b4c605.patch"
-    mkdir -p "$patch_dir"
+    if [ ! -d "$patch_dir" ]; then
+        ln -s ../msquic_patches "$patch_dir"
+    fi
     echo "Patching Msquic 2.3.8"
     for p in patch_1 patch_2 patch_3 patch_4; do
         do_patch "${!p}"

--- a/msquic_patches/12edf3725475d4a99e5598df3289bace47b8f56e.patch
+++ b/msquic_patches/12edf3725475d4a99e5598df3289bace47b8f56e.patch
@@ -1,0 +1,43 @@
+From 12edf3725475d4a99e5598df3289bace47b8f56e Mon Sep 17 00:00:00 2001
+From: Nick Banks <nibanks@microsoft.com>
+Date: Mon, 18 Mar 2024 12:34:17 -0400
+Subject: [PATCH] Fix Posix QuicAddrToString (#4197)
+
+---
+ src/inc/msquic_posix.h | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/inc/msquic_posix.h b/src/inc/msquic_posix.h
+index 612d67afb4..27393e1233 100644
+--- a/src/inc/msquic_posix.h
++++ b/src/inc/msquic_posix.h
+@@ -489,16 +489,18 @@ QuicAddrToString(
+     _Out_ QUIC_ADDR_STR* AddrStr
+     )
+ {
++    size_t AvailSpace = sizeof(AddrStr->Address);
+     char* Address = AddrStr->Address;
+     if (Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET6 && Addr->Ipv6.sin6_port != 0) {
+         Address[0] = '[';
+         Address++;
++        AvailSpace--;
+     }
+     if (inet_ntop(
+             Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET ? AF_INET : AF_INET6,
+             Addr->Ip.sa_family == QUIC_ADDRESS_FAMILY_INET ? (void*)&Addr->Ipv4.sin_addr : (void*)&Addr->Ipv6.sin6_addr,
+             Address,
+-            sizeof(QUIC_ADDR_STR)) == NULL) {
++            AvailSpace) == NULL) {
+         return FALSE;
+     }
+     if (Addr->Ipv4.sin_port != 0) {
+@@ -507,7 +509,8 @@ QuicAddrToString(
+             Address[0] = ']';
+             Address++;
+         }
+-        snprintf(Address, 64, ":%hu", ntohs(Addr->Ipv4.sin_port));
++        AvailSpace = sizeof(AddrStr->Address) - (Address - AddrStr->Address);
++        snprintf(Address, AvailSpace, ":%hu", ntohs(Addr->Ipv4.sin_port));
+     }
+     return TRUE;
+ }

--- a/msquic_patches/9261dacc1dd9a67f6fa8d5fbe663082508b4c605.patch
+++ b/msquic_patches/9261dacc1dd9a67f6fa8d5fbe663082508b4c605.patch
@@ -1,0 +1,23 @@
+From 9261dacc1dd9a67f6fa8d5fbe663082508b4c605 Mon Sep 17 00:00:00 2001
+From: William Yang <mscame@gmail.com>
+Date: Thu, 19 Dec 2024 13:36:38 +0100
+Subject: [PATCH] fix(epoll): buffer overflow when GSO off
+
+---
+ src/platform/datapath_epoll.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/platform/datapath_epoll.c b/src/platform/datapath_epoll.c
+index 92ad4a34aa..9176427831 100644
+--- a/src/platform/datapath_epoll.c
++++ b/src/platform/datapath_epoll.c
+@@ -2154,7 +2154,8 @@ CxPlatSendDataFinalizeSendBuffer(
+         struct iovec* IoVec = &SendData->Iovs[SendData->BufferCount - 1];
+         IoVec->iov_base = SendData->ClientBuffer.Buffer;
+         IoVec->iov_len = SendData->ClientBuffer.Length;
+-        if (SendData->TotalSize + SendData->SegmentSize > sizeof(SendData->Buffer) ||
++        if (SendData->SegmentSize == 0 ||
++            SendData->TotalSize + SendData->SegmentSize > sizeof(SendData->Buffer) ||
+             SendData->BufferCount == SendData->SocketContext->DatapathPartition->Datapath->SendIoVecCount) {
+             SendData->ClientBuffer.Buffer = NULL;
+         } else {

--- a/msquic_patches/README.md
+++ b/msquic_patches/README.md
@@ -1,0 +1,3 @@
+# Cache dir for Msquic Patches
+
+For patch sources see [get-msquic.sh](../get-msquic.sh).

--- a/msquic_patches/b16a14a72e8c74407ee4a079a1f57efe0246f739.patch
+++ b/msquic_patches/b16a14a72e8c74407ee4a079a1f57efe0246f739.patch
@@ -1,0 +1,22 @@
+From b16a14a72e8c74407ee4a079a1f57efe0246f739 Mon Sep 17 00:00:00 2001
+From: William Yang <mscame@gmail.com>
+Date: Thu, 16 May 2024 10:21:54 +0200
+Subject: [PATCH] fix: buffer overflow in quic_trace
+
+---
+ src/generated/stdout/quic_trace.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/generated/stdout/quic_trace.c b/src/generated/stdout/quic_trace.c
+index d550d20101..8c79b270bf 100644
+--- a/src/generated/stdout/quic_trace.c
++++ b/src/generated/stdout/quic_trace.c
+@@ -49,7 +49,7 @@ char * casted_clog_bytearray(const uint8_t * const data,
+         param->str = CXPLAT_ALLOC_PAGED(len * 2 + 1, QUIC_POOL_TMP_ALLOC);
+         if (param->str) {
+             EncodeHexBuffer((uint8_t *)data, (uint8_t)len, param->str);
+-            param->str[len * 2 + 1] = 0;
++            param->str[len * 2] = 0;
+         }
+ 
+     } else {

--- a/msquic_patches/e0201eb4e007e7524aef007be67f2281f949f102.patch
+++ b/msquic_patches/e0201eb4e007e7524aef007be67f2281f949f102.patch
@@ -1,0 +1,25 @@
+From e0201eb4e007e7524aef007be67f2281f949f102 Mon Sep 17 00:00:00 2001
+From: Nick Banks <nibanks@microsoft.com>
+Date: Wed, 25 Sep 2024 14:16:29 -0400
+Subject: [PATCH] Zero out memory from PacketNumber in
+ QuicBindingPreprocessPacket (#4560)
+
+---
+ src/core/binding.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/core/binding.c b/src/core/binding.c
+index 68d538f8fd..b0296a0ca5 100644
+--- a/src/core/binding.c
++++ b/src/core/binding.c
+@@ -1134,7 +1134,9 @@ QuicBindingPreprocessPacket(
+     _Out_ BOOLEAN* ReleaseDatagram
+     )
+ {
+-    CxPlatZeroMemory(&Packet->PacketNumber, sizeof(QUIC_RX_PACKET) - sizeof(uint64_t));
++    CxPlatZeroMemory(   // Zero out everything from PacketNumber forward
++        &Packet->PacketNumber,
++        sizeof(QUIC_RX_PACKET) - offsetof(QUIC_RX_PACKET, PacketNumber));
+     Packet->AvailBuffer = Packet->Buffer;
+     Packet->AvailBufferLength = Packet->BufferLength;
+ 


### PR DESCRIPTION
to handle github HTTP 429 resp while downloading the patches.


```
curl: (22) The requested URL returned error: 429
```

EMQX CI failed due to downloading msquic patches, this caches the patches in quicer source tree