### PR TITLE
feat: dump sslkeylogfile even conn fail

### DIFF
--- a/test/quicer_connection_SUITE.erl
+++ b/test/quicer_connection_SUITE.erl
@@ -23,6 +23,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("kernel/include/file.hrl").
 
 -import(quicer_test_lib, [
     default_listen_opts/1,
@@ -286,6 +287,12 @@ tc_conn_basic_verify_peer_no_cacert(Config) ->
     SPid ! done,
     ensure_server_exit_normal(Ref),
     ok.
+
+tc_sslkeylog_when_verify_fail(Config) ->
+    ServerTargetFName = "SSLKEYLOGFILE",
+    file:delete(ServerTargetFName),
+    ok = tc_conn_basic_verify_peer_no_cacert([{sslkeylogfile, ServerTargetFName} | Config]),
+    {ok, #file_info{type = regular}} = file:read_file_info(ServerTargetFName).
 
 tc_conn_timeout(Config) ->
     Port = select_port(),


### PR DESCRIPTION
This PR enables SSL key log file dumping even when connection verification fails, allowing for debugging of failed TLS handshakes. The change moves the SSL key dumping logic from the successful connection handler to the connection destruction handlers, ensuring secrets are written regardless of connection outcome.

Refactored SSL key log dumping into a reusable safe_dump_conn_tls_secrets function
Added SSL key dumping to both client and server connection destruction paths
Added test case to verify SSL key log file creation when peer verification fails