### PR TITLE
feat: runtime envvar kill switch QUICER_NO_NIF

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       - name: kill switch test
         run: |
           rm -rf priv/*
-          QUICER_NO_NIF=1 rebar3 shell --eval '{ok,fake}=quicer:open_lib(),halt()'
+          QUICER_SKIP_NIF_LOAD=1 rebar3 shell --eval '{ok,fake}=quicer:open_lib(),halt()'
 
   mac-mesh:
     timeout-minutes: 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,11 @@ jobs:
           export QUICER_TLS_VER=sys
           make ci
 
+      - name: kill switch test
+        run: |
+          rm -rf priv/*
+          QUICER_NO_NIF=1 rebar3 shell --eval '{ok,fake}=quicer:open_lib(),halt()'
+
   mac-mesh:
     timeout-minutes: 60
     needs: pre-check

--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -202,6 +202,7 @@ abi_version() ->
     | {ok, false}
     %% opened with lttng debug library loaded (if present)
     | {ok, debug}
+    | {ok, fake}
     | {error, open_failed, atom_reason()}.
 open_lib() ->
     quicer_nif:open_lib().

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -119,7 +119,7 @@
 -include("quicer_types.hrl").
 -include("quicer_vsn.hrl").
 
--define(NONIF_SWITCH, "QUICER_NO_NIF").
+-define(NONIF_SWITCH, "QUICER_SKIP_NIF_LOAD").
 
 -hank([
     {unnecessary_function_arguments, [
@@ -145,8 +145,8 @@ init(ABIVsn) ->
     case os:getenv(?NONIF_SWITCH) of
         "1" ->
             io:format(
-                "~n~nWARN: Detected envvar ~s=1, ~p module is loaded but NOT functional. This is not encouraged and take your own risk!~n~n",
-                [?NONIF_SWITCH, ?MODULE]
+                "~n~nWARN: Detected env ~s=1, QUIC module is loaded but will NOT be functional. This is not encouraged and take your own risk!~n~n",
+                [?NONIF_SWITCH]
             ),
             ok;
         _ ->

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -121,6 +121,13 @@
 
 -define(NONIF_SWITCH, "QUICER_NO_NIF").
 
+-hank([
+    {unnecessary_function_arguments, [
+        {open_lib, 1},
+        {reg_open, 1}
+    ]}
+]).
+
 -spec abi_version() -> abi_version().
 abi_version() ->
     ?QUICER_ABI_VERSION.

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -119,6 +119,8 @@
 -include("quicer_types.hrl").
 -include("quicer_vsn.hrl").
 
+-define(NONIF_SWITCH, "QUICER_NO_NIF").
+
 -spec abi_version() -> abi_version().
 abi_version() ->
     ?QUICER_ABI_VERSION.
@@ -133,6 +135,19 @@ init() ->
     init(ABIVsn).
 
 init(ABIVsn) ->
+    case os:getenv(?NONIF_SWITCH) of
+        "1" ->
+            io:format(
+                "~n~nWARN: Detected envvar ~s=1, ~p module is loaded but NOT functional. This is not encouraged and take your own risk!~n~n",
+                [?NONIF_SWITCH, ?MODULE]
+            ),
+            ok;
+        _ ->
+            do_init(ABIVsn)
+    end.
+
+%% `do_init` ensures success NIF loading.
+do_init(ABIVsn) ->
     NifName = "libquicer_nif",
     {ok, Niflib} = locate_lib(priv_dir(), NifName),
     case erlang:load_nif(Niflib, ABIVsn) of
@@ -162,6 +177,7 @@ init(ABIVsn) ->
     | {ok, false}
     %% opened with lttng debug library loaded (if present)
     | {ok, debug}
+    | {ok, fake}
     | {error, open_failed, atom_reason()}.
 open_lib() ->
     LibFile =
@@ -184,7 +200,7 @@ open_lib() ->
     }).
 
 open_lib(_LttngLib) ->
-    erlang:nif_error(nif_library_not_loaded).
+    maybe_fake_ret({ok, fake}).
 
 -spec close_lib() -> ok.
 close_lib() ->
@@ -192,15 +208,15 @@ close_lib() ->
 
 -spec reg_open() -> ok | {error, badarg | invalid_state}.
 reg_open() ->
-    erlang:nif_error(nif_library_not_loaded).
+    maybe_fake_ret(ok).
 
 -spec reg_open(execution_profile()) -> ok | {error, badarg | invalid_state}.
 reg_open(_) ->
-    erlang:nif_error(nif_library_not_loaded).
+    maybe_fake_ret(ok).
 
 -spec reg_close() -> ok.
 reg_close() ->
-    erlang:nif_error(nif_library_not_loaded).
+    maybe_fake_ret(ok).
 
 -spec new_registration(Name :: string(), Profile :: registration_profile()) -> new_registration().
 new_registration(_Name, _Profile) ->
@@ -501,4 +517,15 @@ lb_server_id(ipv4, DevName) ->
         _:E ->
             logger:error("Failed to set lb mode from ~s, fallback to disabled: ~p", [DevName, E]),
             ?QUIC_LOAD_BALANCING_DISABLED
+    end.
+
+-spec is_kill_switch_enabled() -> boolean().
+is_kill_switch_enabled() ->
+    os:getenv(?NONIF_SWITCH) == "1".
+
+-spec maybe_fake_ret(Ret) -> Ret.
+maybe_fake_ret(Ret) ->
+    case is_kill_switch_enabled() of
+        true -> Ret;
+        _ -> erlang:nif_error(nif_library_not_loaded)
     end.


### PR DESCRIPTION
fix [EEC-951](https://emqx.atlassian.net/browse/EEC-951)

By setting QUICER_NO_NIF=1,
NIF module (quicer_nif) will be loaded successfully, and quicer
application could be started but NONE of the functions can work.

This is used in some deployment that the quicer functions are not
required/desired but quicer app is embedded in release that requires
it to start successfully.