### PR TITLE
fix: prevent warnings of kill switch blocking the boot process.

### DIFF
--- a/src/quicer_app.erl
+++ b/src/quicer_app.erl
@@ -22,6 +22,15 @@
 ]).
 
 start(_StartType, _StartArgs) ->
+    case quicer_nif:is_kill_switch_enabled() of
+        true ->
+            logger:warning(
+                "Detected env ~s=1, QUIC module is loaded but will NOT be functional. This is not encouraged and take your own risk!~n~n",
+                [quicer_nif:kill_switch_name()]
+            );
+        false ->
+            skip
+    end,
     _ = quicer:open_lib(),
     _ = quicer:reg_open(application:get_env(quicer, profile, quic_execution_profile_low_latency)),
     quicer_sup:start_link().

--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -83,6 +83,10 @@
 ]).
 
 -export([abi_version/0]).
+-export([
+    is_kill_switch_enabled/0,
+    kill_switch_name/0
+]).
 
 %% for test
 -export([init/1]).
@@ -145,10 +149,7 @@ init() ->
 init(ABIVsn) ->
     case os:getenv(?NONIF_SWITCH) of
         "1" ->
-            io:format(
-                "~n~nWARN: Detected env ~s=1, QUIC module is loaded but will NOT be functional. This is not encouraged and take your own risk!~n~n",
-                [?NONIF_SWITCH]
-            ),
+            %% Warning will be printed after the load.
             ok;
         _ ->
             do_init(ABIVsn)
@@ -541,3 +542,7 @@ maybe_fake_ret(Ret) ->
         true -> Ret;
         _ -> erlang:nif_error(nif_library_not_loaded)
     end.
+
+-spec kill_switch_name() -> string().
+kill_switch_name() ->
+    ?NONIF_SWITCH.


### PR DESCRIPTION
EMQX 5 booting get blocking if kill switch is enabled as io blocking. 
The reason is unknown,  it may due to the embeded mode or `noshell`? 

(rebar3 shell was tested without getting blocked)

NOTE: Does not work with EMQX 6 with mix build. 