### PR TITLE
Use env-based shebang for sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -ueo pipefail
 


### PR DESCRIPTION
Hey friends 👋

On some systems (notably Nix-based environments), `/bin/bash` does not exist at that path, even though a POSIX‐compatible bash is available in the user’s environment. In those cases, the script fails to execute with a misleading “No such file or directory” error, even though the file itself is present and executable.

In my case, this currently prevents [emqx/emqtt](https://github.com/emqx/emqtt) from building as part of my Elixir project's dependency chain, with the failure happening during make / rebar3:
```
make: ./build.sh: No such file or directory
make: *** [Makefile:15: build-nif] Error 127
===> Hook for compile failed!
```

Using `#!/usr/bin/env bash` allows the system to resolve bash via PATH, which is more portable across different Unix-like environments and avoids hard-coding assumptions about filesystem layout. This is a fairly common convention for build scripts that don’t rely on a specific shell implementation.

There’s a short discussion of this exact issue here, if some context helps:
https://news.ycombinator.com/item?id=22616429

Happy to adjust if there’s a preference for a different approach, but this small change unblocks builds in environments where /bin/sh isn’t guaranteed to exist.

Thanks!