### PR TITLE
Fix spec of peer_address_changed() callback

### DIFF
--- a/src/quicer_connection.erl
+++ b/src/quicer_connection.erl
@@ -93,7 +93,7 @@
 -callback local_address_changed(connection_handle(), quicer_addr(), cb_state()) -> cb_ret().
 %% Handle Local Addr Changed, currently not in use.
 
--callback peer_address_changed(connection_handle(), quicer_addr(), cb_state) -> cb_ret().
+-callback peer_address_changed(connection_handle(), quicer_addr(), cb_state()) -> cb_ret().
 %% Handle Peer Addr Changed
 
 -callback streams_available(


### PR DESCRIPTION
It is currently stating that it receives a `cb_state` atom. Type-checkers like `eqwalizer` then report problems on the IMPLEMENTATIONS of this callback.