### PR TITLE
Make quicer_stream:cb_ret() an alias to quicer_lib:cb_ret()

### DIFF
--- a/src/quicer_stream.erl
+++ b/src/quicer_stream.erl
@@ -81,19 +81,7 @@
 -export_type([cb_state/0, cb_ret/0]).
 
 -type cb_state() :: term().
-%% ok and update cb_state
--type cb_ret() ::
-    {ok, cb_state()}
-    %% error handling per callback
-    | {error, Reason :: term(), cb_state()}
-    %% ok but also hibernate process
-    | {hibernate, cb_state()}
-    %% split callback work with Continue
-    | {{continue, Continue :: term()}, cb_state()}
-    %% ok but also hibernate process
-    | {timeout(), cb_state()}
-    %% terminate with reason
-    | {stop, Reason :: term(), cb_state()}.
+-type cb_ret() :: quicer_lib:cb_ret().
 
 %% API
 


### PR DESCRIPTION
`quicer_stream:cb_ret()` is currently a subtype of `quicer_lib;cb_ret()`; in particular, it is missing the `reply` terms. This means that implementations of the behaviour cannot use `reply` terms for their `handle_call()` impkementation without type-checkers like eqwalizer (correctly) flagging it as a violation of the spec.

Because `quicer_lib:default_cb_ret()` is used anyway, it is safe to use `quicer_lib:cb_ret()` here. This also follows the pattern in `quicer_connection`.