### PR TITLE
Fix spec of quic_listener:start_link/3

### DIFF
--- a/src/quicer_listener.erl
+++ b/src/quicer_listener.erl
@@ -76,8 +76,7 @@
 -spec start_link(
     Name :: listener_name(),
     ListenOn :: quicer:listen_on(),
-    Options ::
-        {quicer:listener_opts(), quicer:conn_opts(), quicer:stream_opts()}
+    Options :: quicer:listener_opts()
 ) ->
     {ok, Pid :: pid()}
     | {error, Error :: {already_started, pid()}}


### PR DESCRIPTION
The spec is incorrect, and dialyzer and eqwalizer flag any call to this function