### PR TITLE
Add optional handle_cast() callbacks to quicer_connection and quicer_…

### DIFF
--- a/src/quicer_connection.erl
+++ b/src/quicer_connection.erl
@@ -129,6 +129,9 @@
 
 -callback handle_call(Req :: term(), From :: gen_server:from(), cb_state()) -> cb_ret().
 
+-callback handle_cast(Req :: term(), cb_state()) -> cb_ret().
+%% Handle cast with callback state.
+
 -callback handle_info(Info :: term(), cb_state()) -> cb_ret().
 %% handle unhandled info with callback state.
 
@@ -137,6 +140,7 @@
 
 -optional_callbacks([
     handle_call/3,
+    handle_cast/2,
     handle_info/2,
     handle_continue/2,
     %% require newer MsQuic
@@ -408,8 +412,13 @@ handle_call(Request, From, #{callback_state := CBState, callback := M} = State) 
     | {noreply, NewState :: term(), Timeout :: timeout()}
     | {noreply, NewState :: term(), hibernate}
     | {stop, Reason :: term(), NewState :: term()}.
-handle_cast(_Request, State) ->
-    {noreply, State}.
+handle_cast(Request, #{callback := M, callback_state := CBState} = State) ->
+    case erlang:function_exported(M, handle_cast, 2) of
+        true ->
+            default_cb_ret(M:handle_cast(Request, CBState), State);
+        false ->
+            {noreply, State}
+    end.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/src/quicer_stream.erl
+++ b/src/quicer_stream.erl
@@ -76,7 +76,12 @@
 %% Handle unhandled info with callback state.
 
 -optional_callbacks([
-    post_handoff/3, handle_stream_data/4, handle_call/3, handle_cast/2, handle_info/2, handle_continue/2
+    post_handoff/3,
+    handle_stream_data/4,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    handle_continue/2
 ]).
 
 -import(quicer_lib, [default_cb_ret/2]).

--- a/src/quicer_stream.erl
+++ b/src/quicer_stream.erl
@@ -66,6 +66,9 @@
 -callback handle_call(Req :: term(), gen_server:from(), cb_state()) -> cb_ret().
 %% Handle API call with callback state.
 
+-callback handle_cast(Req :: term(), cb_state()) -> cb_ret().
+%% Handle cast with callback state.
+
 -callback handle_continue(Cont :: term(), cb_state()) -> cb_ret().
 %% Handle continue from other callbacks with callback state.
 
@@ -73,7 +76,7 @@
 %% Handle unhandled info with callback state.
 
 -optional_callbacks([
-    post_handoff/3, handle_stream_data/4, handle_call/3, handle_info/2, handle_continue/2
+    post_handoff/3, handle_stream_data/4, handle_call/3, handle_cast/2, handle_info/2, handle_continue/2
 ]).
 
 -import(quicer_lib, [default_cb_ret/2]).
@@ -366,8 +369,13 @@ handle_call(
     | {noreply, state(), Timeout :: timeout()}
     | {noreply, state(), hibernate}
     | {stop, Reason :: term(), state()}.
-handle_cast(_Request, State) ->
-    {noreply, State}.
+handle_cast(Request, #{callback := M, callback_state := CBState} = State) ->
+    case erlang:function_exported(M, handle_cast, 2) of
+        true ->
+            default_cb_ret(M:handle_cast(Request, CBState), State);
+        false ->
+            {noreply, State}
+    end.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/test/example/exit2.lux
+++ b/test/example/exit2.lux
@@ -4,7 +4,7 @@
 
 [shell client]
     !$_CTRL_C_
-    ?BREAK
+    ?(BREAK|ERR \{error,interrupted\})
     !a
 
 

--- a/test/example/qt.erl
+++ b/test/example/qt.erl
@@ -53,10 +53,36 @@ s() ->
                peer_bidi_stream_count => 64000,
                alpn => ["sample"]
               },
-  proc_lib:spawn_link(fun() ->
-                          {ok, L} = quicer:listen(Port, LOptions),
-                          listener(L)
-                      end).
+  Parent = self(),
+  Pid = proc_lib:spawn_link(
+          fun() ->
+              {ok, L} = listen_with_retry(Port, LOptions),
+              io:format("qt server ready\n"),
+              Parent ! {self(), ready},
+              listener(L)
+          end),
+  receive
+    {Pid, ready} ->
+      ok
+  after 10000 ->
+      exit(server_start_timeout)
+  end,
+  Pid.
+
+listen_with_retry(Port, Options) ->
+  listen_with_retry(Port, Options, 20).
+listen_with_retry(Port, Options, 0) ->
+  quicer:listen(Port, Options);
+listen_with_retry(Port, Options, N) ->
+  case quicer:listen(Port, Options) of
+    {ok, _} = Ok -> Ok;
+    {error, _} ->
+      timer:sleep(500),
+      listen_with_retry(Port, Options, N - 1);
+    {error, _, _} ->
+      timer:sleep(500),
+      listen_with_retry(Port, Options, N - 1)
+  end.
 
 
 listener(L) ->
@@ -414,6 +440,10 @@ client(Conns, Streams, CNo, SNo) ->
       client(C2, S2, CNo, SNo);
     {ok, exit} ->
       exit(normal);
+    {error, interrupted} = Err ->
+      io:format("ERR ~p~n", [Err]),
+      close_all(Conns, Streams),
+      client([], [], CNo, SNo);
     Err ->
       io:format("ERR ~p~n", [Err]),
       client(Conns, Streams, CNo, SNo)
@@ -464,6 +494,20 @@ flush(Conns, Streams) ->
   after 10 ->
       {Conns, Streams}
   end.
+
+
+close_all(Conns, Streams) ->
+  lists:foreach(
+    fun({Stm, _, _}) ->
+        _ = quicer:close_stream(Stm),
+        ok
+    end, Streams),
+  lists:foreach(
+    fun({Conn, _}) ->
+        _ = quicer:close_connection(Conn),
+        ok
+    end, Conns),
+  ok.
 
 
 check_processes() ->

--- a/test/example/rev.erl
+++ b/test/example/rev.erl
@@ -108,7 +108,7 @@ top_site() ->
                alpn => ["sample"]
               },
 
-  {ok, L} = quicer:listen(Port, LOptions),
+  {ok, L} = listen_with_retry(Port, LOptions),
   {ok, Conn} = quicer:accept(L, #{active => false}, infinity),
   {ok, Conn} = quicer:handshake(Conn),
   top_loop(Conn).
@@ -160,6 +160,21 @@ c_opts() ->
     peer_bidi_stream_count => 64000,
     handshake_idle_timeout_ms => 3 * ?INTERVAL,
     idle_timeout_ms => 3 * ?INTERVAL}.
+
+listen_with_retry(Port, Options) ->
+  listen_with_retry(Port, Options, 20).
+listen_with_retry(Port, Options, 0) ->
+  quicer:listen(Port, Options);
+listen_with_retry(Port, Options, N) ->
+  case quicer:listen(Port, Options) of
+    {ok, _} = Ok -> Ok;
+    {error, _} ->
+      timer:sleep(500),
+      listen_with_retry(Port, Options, N - 1);
+    {error, _, _} ->
+      timer:sleep(500),
+      listen_with_retry(Port, Options, N - 1)
+  end.
 
 nat_site() ->
   Port = 4567,

--- a/test/example/simple.inc
+++ b/test/example/simple.inc
@@ -4,7 +4,7 @@
 
 [shell server]
     !erl -sname s -pa ../../_build/default/lib/quicer/ebin -s qt s
-    ?$eprompt
+    ?qt server ready
 
 
 [shell client]

--- a/test/example_client_connection.erl
+++ b/test/example_client_connection.erl
@@ -45,6 +45,7 @@
     dgram_state_changed/3
 ]).
 
+-export([handle_call/3, handle_cast/2]).
 -export([handle_info/2]).
 
 start_link(Host, Port, {_COpts, _SOpts} = Opts) ->
@@ -155,6 +156,19 @@ peer_needs_streams(C, bidi_streams, S) ->
     {ok, Current} = quicer:getopt(C, local_bidi_stream_count),
     ok = quicer:setopt(C, settings, #{peer_bidi_stream_count => Current + 1}),
     {ok, S}.
+
+handle_call({set_foo, Value}, _From, State) ->
+    {reply, ok, State#{foo => Value}};
+handle_call(get_foo, _From, State) ->
+    {reply, maps:get(foo, State, undefined), State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, not_impl}, State}.
+
+handle_cast(ping, State) ->
+    ?tp(debug, #{module => ?MODULE, event => handle_cast_ping}),
+    {ok, State};
+handle_cast(_Request, State) ->
+    {ok, State}.
 
 handle_info({'EXIT', _Pid, _Reason}, State) ->
     {ok, State};

--- a/test/example_client_stream.erl
+++ b/test/example_client_stream.erl
@@ -31,6 +31,7 @@
     peer_accepted/3,
     passive/3,
     handle_call/3,
+    handle_cast/2,
     handle_info/2
 ]).
 
@@ -175,8 +176,18 @@ stream_closed(
 ->
     {stop, normal, S}.
 
+handle_call({set_foo, Value}, _From, State) ->
+    {reply, ok, State#{foo => Value}};
+handle_call(get_foo, _From, State) ->
+    {reply, maps:get(foo, State, undefined), State};
 handle_call(_Request, _From, S) ->
     {reply, {error, not_impl}, S}.
+
+handle_cast(ping, State) ->
+    ?tp(debug, #{module => ?MODULE, event => handle_cast_ping}),
+    {ok, State};
+handle_cast(_Request, State) ->
+    {ok, State}.
 
 handle_info(_, S) ->
     {ok, S}.

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -3363,7 +3363,11 @@ tc_handle_cast_conn(Config) ->
             ),
             gen_server:cast(ClientConnPid, ping),
             {ok, _} = ?block_until(
-                #{?snk_kind := debug, event := handle_cast_ping, module := example_client_connection},
+                #{
+                    ?snk_kind := debug,
+                    event := handle_cast_ping,
+                    module := example_client_connection
+                },
                 1000
             ),
             gen_server:stop(ClientConnPid)

--- a/test/quicer_snb_SUITE.erl
+++ b/test/quicer_snb_SUITE.erl
@@ -58,7 +58,11 @@
     tc_multi_streams_example_server_1/1,
     tc_multi_streams_example_server_2/1,
     tc_multi_streams_example_server_3/1,
-    tc_passive_recv_1/1
+    tc_passive_recv_1/1,
+    tc_handle_cast_conn/1,
+    tc_handle_cast_stream/1,
+    tc_handle_call_conn/1,
+    tc_handle_call_stream/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -222,7 +226,12 @@ all() ->
         tc_multi_streams_example_server_1,
         tc_multi_streams_example_server_2,
         tc_multi_streams_example_server_3,
-        tc_passive_recv_1
+        tc_passive_recv_1,
+        %% handle_cast and handle_call
+        tc_handle_cast_conn,
+        tc_handle_cast_stream,
+        tc_handle_call_conn,
+        tc_handle_call_stream
     ].
 
 %%--------------------------------------------------------------------
@@ -3314,6 +3323,208 @@ tc_passive_recv_1(Config) ->
                 ])
             )
         end
+    ),
+    ok.
+
+tc_handle_cast_conn(Config) ->
+    ServerConnCallback = example_server_connection,
+    ServerStreamCallback = example_server_stream,
+    Port = select_port(),
+    application:ensure_all_started(quicer),
+    ListenerOpts = [
+        {conn_acceptors, 32},
+        {peer_bidi_stream_count, 0},
+        {peer_unidi_stream_count, 1}
+        | default_listen_opts(Config)
+    ],
+    ConnectionOpts = [
+        {conn_callback, ServerConnCallback},
+        {stream_acceptors, 2}
+        | default_conn_opts()
+    ],
+    StreamOpts = [
+        {stream_callback, ServerStreamCallback}
+        | default_stream_opts()
+    ],
+    Options = {ListenerOpts, ConnectionOpts, StreamOpts},
+    ?my_check_trace(
+        #{timetrap => 10000},
+        begin
+            {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
+            {ok, ClientConnPid} = example_client_connection:start_link(
+                "localhost",
+                Port,
+                {default_conn_opts(), default_stream_opts()}
+            ),
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, event := connected, module := example_client_connection},
+                5000,
+                1000
+            ),
+            gen_server:cast(ClientConnPid, ping),
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, event := handle_cast_ping, module := example_client_connection},
+                1000
+            ),
+            gen_server:stop(ClientConnPid)
+        end,
+        fun(_Result, _Trace) -> ok end
+    ),
+    ok.
+
+tc_handle_cast_stream(Config) ->
+    ServerConnCallback = example_server_connection,
+    ServerStreamCallback = example_server_stream,
+    Port = select_port(),
+    application:ensure_all_started(quicer),
+    ListenerOpts = [
+        {conn_acceptors, 32},
+        {peer_bidi_stream_count, 0},
+        {peer_unidi_stream_count, 1}
+        | default_listen_opts(Config)
+    ],
+    ConnectionOpts = [
+        {conn_callback, ServerConnCallback},
+        {stream_acceptors, 2}
+        | default_conn_opts()
+    ],
+    StreamOpts = [
+        {stream_callback, ServerStreamCallback}
+        | default_stream_opts()
+    ],
+    Options = {ListenerOpts, ConnectionOpts, StreamOpts},
+    ?my_check_trace(
+        #{timetrap => 10000},
+        begin
+            {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
+            {ok, ClientConnPid} = example_client_connection:start_link(
+                "localhost",
+                Port,
+                {default_conn_opts(), default_stream_opts()}
+            ),
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, event := connected, module := example_client_connection},
+                5000,
+                1000
+            ),
+            %% Wait for the remote stream data so the receiver's callback_state is initialized
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, dir := remote_unidir, module := example_client_stream},
+                5000,
+                1000
+            ),
+            {_Sender, Receiver} = maps:get(
+                master_stream_pair, quicer_connection:get_cb_state(ClientConnPid)
+            ),
+            ?assert(is_process_alive(Receiver)),
+            gen_server:cast(Receiver, ping),
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, event := handle_cast_ping, module := example_client_stream},
+                1000
+            ),
+            gen_server:stop(ClientConnPid)
+        end,
+        fun(_Result, _Trace) -> ok end
+    ),
+    ok.
+
+tc_handle_call_conn(Config) ->
+    ServerConnCallback = example_server_connection,
+    ServerStreamCallback = example_server_stream,
+    Port = select_port(),
+    application:ensure_all_started(quicer),
+    ListenerOpts = [
+        {conn_acceptors, 32},
+        {peer_bidi_stream_count, 0},
+        {peer_unidi_stream_count, 1}
+        | default_listen_opts(Config)
+    ],
+    ConnectionOpts = [
+        {conn_callback, ServerConnCallback},
+        {stream_acceptors, 2}
+        | default_conn_opts()
+    ],
+    StreamOpts = [
+        {stream_callback, ServerStreamCallback}
+        | default_stream_opts()
+    ],
+    Options = {ListenerOpts, ConnectionOpts, StreamOpts},
+    ?my_check_trace(
+        #{timetrap => 10000},
+        begin
+            {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
+            {ok, ClientConnPid} = example_client_connection:start_link(
+                "localhost",
+                Port,
+                {default_conn_opts(), default_stream_opts()}
+            ),
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, event := connected, module := example_client_connection},
+                5000,
+                1000
+            ),
+            undefined = gen_server:call(ClientConnPid, get_foo),
+            ok = gen_server:call(ClientConnPid, {set_foo, bar}),
+            bar = gen_server:call(ClientConnPid, get_foo),
+            ok = gen_server:call(ClientConnPid, {set_foo, baz}),
+            baz = gen_server:call(ClientConnPid, get_foo),
+            gen_server:stop(ClientConnPid)
+        end,
+        fun(_Result, _Trace) -> ok end
+    ),
+    ok.
+
+tc_handle_call_stream(Config) ->
+    ServerConnCallback = example_server_connection,
+    ServerStreamCallback = example_server_stream,
+    Port = select_port(),
+    application:ensure_all_started(quicer),
+    ListenerOpts = [
+        {conn_acceptors, 32},
+        {peer_bidi_stream_count, 0},
+        {peer_unidi_stream_count, 1}
+        | default_listen_opts(Config)
+    ],
+    ConnectionOpts = [
+        {conn_callback, ServerConnCallback},
+        {stream_acceptors, 2}
+        | default_conn_opts()
+    ],
+    StreamOpts = [
+        {stream_callback, ServerStreamCallback}
+        | default_stream_opts()
+    ],
+    Options = {ListenerOpts, ConnectionOpts, StreamOpts},
+    ?my_check_trace(
+        #{timetrap => 10000},
+        begin
+            {ok, _QuicApp} = quicer:spawn_listener(mqtt, Port, Options),
+            {ok, ClientConnPid} = example_client_connection:start_link(
+                "localhost",
+                Port,
+                {default_conn_opts(), default_stream_opts()}
+            ),
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, event := connected, module := example_client_connection},
+                5000,
+                1000
+            ),
+            %% Wait for the remote stream data so the receiver's callback_state is initialized
+            {ok, _} = ?block_until(
+                #{?snk_kind := debug, dir := remote_unidir, module := example_client_stream},
+                5000,
+                1000
+            ),
+            {_Sender, Receiver} = maps:get(
+                master_stream_pair, quicer_connection:get_cb_state(ClientConnPid)
+            ),
+            ?assert(is_process_alive(Receiver)),
+            undefined = gen_server:call(Receiver, get_foo),
+            ok = gen_server:call(Receiver, {set_foo, bar}),
+            bar = gen_server:call(Receiver, get_foo),
+            gen_server:stop(ClientConnPid)
+        end,
+        fun(_Result, _Trace) -> ok end
     ),
     ok.
 


### PR DESCRIPTION
…stream

So that it is possible to use `gen_server:cast()` on behaviour implementations