### PR TITLE
build: detect macOS architecture for CMake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,40 @@ MSQUIC_VERSION="$1"
 TARGET_SO='priv/libquicer_nif.so'
 PKGNAME="$(./pkgname.sh)"
 
+detect_macos_arch() {
+    local arch=""
+
+    # The NIF must match the architecture of the running Erlang VM. Prefer
+    # Erlang's own target triplet so Rosetta shells don't accidentally choose
+    # the host/shell architecture instead of the VM architecture.
+    if command -v erl >/dev/null 2>&1; then
+        arch="$(erl -noshell -eval 'io:format("~s", [erlang:system_info(system_architecture)]), halt().' 2>/dev/null | cut -d- -f1 || true)"
+    fi
+
+    case "$arch" in
+        aarch64 | arm64)
+            echo arm64
+            ;;
+        x86_64 | amd64)
+            echo x86_64
+            ;;
+        *)
+            arch="$(uname -m)"
+            case "$arch" in
+                aarch64 | arm64)
+                    echo arm64
+                    ;;
+                x86_64 | amd64)
+                    echo x86_64
+                    ;;
+                *)
+                    echo "$arch"
+                    ;;
+            esac
+            ;;
+    esac
+}
+
 build() {
     # default: 4 concurrent jobs
     JOBS=4
@@ -19,7 +53,10 @@ build() {
     fi
     if [ "$(uname -s)" = 'Darwin' ]; then
         JOBS="$(sysctl -n hw.ncpu)"
-        export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+        export CMAKE_OSX_ARCHITECTURES="${CMAKE_OSX_ARCHITECTURES:-$(detect_macos_arch)}"
+        if [ -z "${SDKROOT:-}" ]; then
+            export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+        fi
     else
         JOBS="$(nproc)"
     fi


### PR DESCRIPTION
Fixes #413.
Related to #329 and #377.

## What changed

`build.sh` now sets `CMAKE_OSX_ARCHITECTURES` on macOS when the caller has not already provided it.

The default is derived from the running Erlang VM via `erlang:system_info(system_architecture)`, with a `uname -m` fallback. This keeps the NIF architecture aligned with the VM architecture and avoids Rosetta shell/host mismatches.

The existing `SDKROOT` setup now also preserves a caller-provided `SDKROOT` instead of unconditionally overwriting it.

## Why

msquic's OpenSSL/QuicTLS Darwin configure path expects `CMAKE_OSX_ARCHITECTURES` to be `arm64` or `x86_64`. If CMake leaves it empty, the build can fall through to the generic OpenSSL `config` path (`ERRORWTF darwin` in older msquic), causing architecture mismatch and/or bad `-isysroot` compiler flags.

## Verified

On Apple Silicon/macOS:

```sh
bash -n build.sh
rm -rf c_build priv _build msquic && mkdir -p priv && ./build.sh v2.5.5
~/.mix/elixir/1-19-otp-28/rebar3 compile
```

Confirmed generated cache/configure output includes:

```text
CMAKE_OSX_ARCHITECTURES:STRING=arm64
CMAKE_OSX_SYSROOT:PATH=/Applications/Xcode.app/.../MacOSX26.4.sdk
-- Configuring OpenSSL: ARCHFLAGS="-arch arm64";...;darwin64-arm64-cc ...
```
