### PR TITLE
fix: adapt to msquic 2.4 new recv mode.

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -1425,14 +1425,27 @@ set_stream_opt(ErlNifEnv *env,
       enif_mutex_lock(s_ctx->lock);
 
       if (ACCEPTOR_RECV_MODE_PASSIVE == s_ctx->owner->active
-          && !IS_SAME_TERM(ATOM_FALSE, optval) && s_ctx->TotalBufferLength > 0)
+          && !IS_SAME_TERM(ATOM_FALSE, optval))
         {
-          // Trigger callback of event recv.
+          // Switching from passive to active: msquic receives may have been
+          // disabled (e.g. by a partial passive recv, or when an {active, N}
+          // count was exhausted).
+          // Re-enable them unconditionally.
+          //
+          // Order matters: enable BEFORE completing the pending recv. In
+          // single recv-buffer mode, StreamReceiveSetEnabled(TRUE) will NOT
+          // queue a recv flush while a read is still pending
+          // (ReadPendingLength > 0). By enabling first and then completing
+          // recv with 0, the completion itself drives the flush
+          // (QuicStreamReceiveComplete re-flushes once ReceiveEnabled is
+          // TRUE), so delivery does not depend on the enable-time flush guard.
+          MsQuic->StreamReceiveSetEnabled(s_ctx->Stream, TRUE);
           if (s_ctx->is_recv_pending)
             {
+              // Complete the pending recv (consuming 0 bytes) so the data is
+              // re-indicated now that receives are re-enabled.
               MsQuic->StreamReceiveComplete(s_ctx->Stream, 0);
             }
-          MsQuic->StreamReceiveSetEnabled(s_ctx->Stream, TRUE);
         }
       if (!set_owner_recv_mode(s_ctx->owner, env, optval))
         {

--- a/c_src/quicer_stream.c
+++ b/c_src/quicer_stream.c
@@ -785,14 +785,16 @@ recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
       TP_NIF_3(more, (uintptr_t)s_ctx->Stream, size_req);
       s_ctx->is_wait_for_data = TRUE;
 
-      // Finish the stream recv callback
-      if (s_ctx->is_recv_pending)
-        {
-          MsQuic->StreamReceiveComplete(s_ctx->Stream, 0);
-        }
       //
-      // Ensure stream recv is enabled while it is in passive mode.
-      // because we are waiting for more data
+      // Ensure stream recv is enabled while it is in passive mode,
+      // because we are waiting for more data.
+      //
+      // Enable BEFORE finishing any pending recv callback: in single
+      // recv-buffer mode StreamReceiveSetEnabled(TRUE) won't flush while a
+      // read is still pending, so we let the completion drive the flush
+      // instead (see the matching note in set_stream_opt). On this branch
+      // is_recv_pending is normally FALSE, so the completion is just a safety
+      // net.
       //
       if (QUIC_FAILED(status
                       = MsQuic->StreamReceiveSetEnabled(s_ctx->Stream, TRUE)))
@@ -800,12 +802,14 @@ recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
           res = ERROR_TUPLE_2(ATOM_STATUS(status));
           goto Exit;
         }
-      else
+      // Finish the stream recv callback
+      if (s_ctx->is_recv_pending)
         {
-          // NIF caller will get {ok, not_ready}
-          // this is an ack to its call
-          res = SUCCESS(ATOM_ERROR_NOT_READY);
+          MsQuic->StreamReceiveComplete(s_ctx->Stream, 0);
         }
+      // NIF caller will get {ok, not_ready}
+      // this is an ack to its call
+      res = SUCCESS(ATOM_ERROR_NOT_READY);
     }
 
 Exit:

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -68,6 +68,8 @@
     %% , tc_stream_sendrecv_large_data_passive_2/1
     tc_stream_sendrecv_large_data_active/1,
     tc_stream_passive_switch_to_active/1,
+    tc_stream_passive_partial_recv_switch_to_active_n/1,
+    tc_stream_passive_pending_switch_to_active_n/1,
     tc_stream_active_switch_to_passive/1,
     tc_stream_controlling_process/1,
     tc_stream_controlling_process_demon/1,
@@ -579,6 +581,66 @@ tc_stream_passive_switch_to_active(Config) ->
             ensure_server_exit_normal(Ref)
     after 6000 ->
         ct:fail("timeout")
+    end.
+
+%% @doc A partial passive recv must not strand the remaining data when switching to {active, N}.
+tc_stream_passive_partial_recv_switch_to_active_n(Config) ->
+    Port = select_port(),
+    Owner = self(),
+    {SPid, Ref} = spawn_monitor(fun() -> echo_server(Owner, Config, Port) end),
+    receive
+        listener_ready ->
+            %% GIVEN: a passive stream that has received a single 10-byte frame,
+            %%        of which only 1 byte is consumed by a passive recv. The
+            %%        partial completion pauses msquic receives and leaves 9
+            %%        bytes buffered.
+            {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
+            {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
+            {ok, 10} = quicer:send(Stm, <<"0123456789">>),
+            {ok, <<"0">>} = quicer:recv(Stm, 1),
+            %% WHEN: the stream is switched to active mode.
+            ok = quicer:setopt(Stm, active, 3),
+            %% THEN: the buffered remaining 9 bytes are delivered as active messages.
+            <<"123456789">> = recv_active_bytes(Stm, 9, 5000),
+            SPid ! done,
+            ensure_server_exit_normal(Ref)
+    after 6000 ->
+        ct:fail("timeout")
+    end.
+
+%% @doc A pending (un-recv'd) passive receive must be delivered after switching to {active, N}.
+tc_stream_passive_pending_switch_to_active_n(Config) ->
+    Port = select_port(),
+    Owner = self(),
+    {SPid, Ref} = spawn_monitor(fun() -> echo_server(Owner, Config, Port) end),
+    receive
+        listener_ready ->
+            %% GIVEN: a passive stream with received data left pending, i.e. the
+            %%        owner never calls recv, so the recv callback pends it
+            %%        (is_recv_pending = TRUE) without signalling the owner.
+            {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
+            {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
+            {ok, 10} = quicer:send(Stm, <<"0123456789">>),
+            timer:sleep(300),
+            %% WHEN: the stream is switched to active mode.
+            ok = quicer:setopt(Stm, active, 3),
+            %% THEN: the pending receive is completed and re-indicated as active messages.
+            <<"0123456789">> = recv_active_bytes(Stm, 10, 5000),
+            SPid ! done,
+            ensure_server_exit_normal(Ref)
+    after 6000 ->
+        ct:fail("timeout")
+    end.
+
+%% Collect `N' bytes worth of active-mode stream data messages for `Stm'.
+recv_active_bytes(_Stm, 0, _Timeout) ->
+    <<>>;
+recv_active_bytes(Stm, N, Timeout) when N > 0 ->
+    receive
+        {quic, Bin, Stm, _Props} when is_binary(Bin) ->
+            <<Bin/binary, (recv_active_bytes(Stm, N - byte_size(Bin), Timeout))/binary>>
+    after Timeout ->
+        ct:fail("timeout waiting for ~p more active bytes on ~p", [N, Stm])
     end.
 
 tc_stream_active_switch_to_passive(Config) ->


### PR DESCRIPTION
quicer was depending on undoc behavior of old msquic < 2.4 that we use StreamReceiveComplete and then StreamReceiveSetEnabled to reactivate the receiving (setopt active_n).

the behavior is now changed (as the order matters) since msquic 2.4 (Multiple Receive API support), this commit adapt to it.

Without this change, there will be lots of flaky test (1/20 fail) due to receiving stall.