### PR TITLE
Export quicer_nif:open_lib/1

### DIFF
--- a/src/quicer_nif.erl
+++ b/src/quicer_nif.erl
@@ -16,6 +16,7 @@
 -module(quicer_nif).
 -export([
     open_lib/0,
+    open_lib/1,
     close_lib/0,
     reg_open/0,
     reg_open/1,


### PR DESCRIPTION
## Summary

- export `quicer_nif:open_lib/1` from the Erlang module
- keep the Erlang export table aligned with the C NIF function table

## Root cause

`c_src/quicer_nif.c` registers `open_lib/1`, but `src/quicer_nif.erl` only exported `open_lib/0`. In embedded/on-load flows this can make the NIF load fail because the NIF table contains a function that is not exported by the Erlang module.

## Validation

- Ran a static check that compares NIF functions registered in `c_src/quicer_nif.c` with exports declared in `src/quicer_nif.erl`; missing count is now `0`.
- Ran `rebar3 compile` successfully, including the msquic/quictls native build and quicer compilation.
