### PR TITLE
test upgrade from 0.2.5

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -29,6 +29,11 @@ jobs:
         otp-version: ${{ matrix.otp }}
         rebar3-version: ${{ matrix.rebar3 }}
 
+    - name: Start epmd
+      run: |
+        epmd -daemon
+        epmd -names
+
     - name: Run cover
       env:
         QUICER_TLS_VER: ${{ matrix.openssl }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
       matrix:
         # https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
         otp:
-          - '26.2.5.14'
+          - '26.2.5.21'
           - '27.3'
           - '28.3'
         openssl:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ matrix.rebar3 }}
+      - name: Start epmd
+        run: |
+          epmd -daemon
+          epmd -names
       - name: release build with debug log off
         run: |
           echo "github ref: ${{ github.event.ref }}"
@@ -101,6 +105,10 @@ jobs:
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           brew install erlang@${{ matrix.otp }}
           echo "$(brew --prefix erlang@${{ matrix.otp }})/bin" >> $GITHUB_PATH
+      - name: Start epmd
+        run: |
+          epmd -daemon
+          epmd -names
       - name: release build
         env:
           QUICER_TLS_VER: ${{ matrix.openssl }}
@@ -165,6 +173,10 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ matrix.rebar3 }}
+      - name: Start epmd
+        run: |
+          epmd -daemon
+          epmd -names
       - name: release build with debug log off
         env:
           CMAKE_BUILD_TYPE: ${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           sudo sysctl -w kernel.core_pattern=core
           ulimit -c unlimited
           export CMAKE_BUILD_TYPE=Debug
-          export QUICER_TLS_VER=sys
+          export QUICER_TLS_VER=quictls
           make ci
 
       - name: gdb bt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,19 @@ jobs:
           export QUICER_TLS_VER=sys
           make ci
 
+      - name: gdb bt
+        if: failure()
+        run: |
+          set -x
+          which gdb || sudo apt install gdb
+          corefile=$(find _build/test -name core)
+          if [ -n "$corefile" ]; then
+          echo "found corefile: $corefile";
+          gdb -ex bt $(erl -noshell -eval 'io:format(code:root_dir()),halt()')/erts-*/bin/beam.smp "${corefile}"
+          else
+          echo "No coredump found"
+          fi
+
       - name: Archive CT Logs
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: failure()

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Project Status: Preview
 
 ``` erlang
 {deps, [
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.4"}}},
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.4"}}},
     ...
 ```
 
@@ -34,7 +34,7 @@ Project Status: Preview
 ``` elixir
 defp deps do
   [
-    {:quicer, git: "https://github.com/emqx/quic.git", tag: "0.2.4"},
+    {:quicer, git: "https://github.com/emqx/quic.git", tag: "0.4.4"},
     ...
   ]
 end
@@ -153,6 +153,10 @@ Client could specify the connect param `sslkeylogfile` to record tls secrets for
         5000
     )
 ```
+
+# Hot upgrade
+
+Supports patch-level hot upgrades only (e.g., a.b.x -> a.b.y).
 
 # License
 Apache License Version 2.0

--- a/test/quicer_upgrade_SUITE.erl
+++ b/test/quicer_upgrade_SUITE.erl
@@ -137,7 +137,8 @@ groups() ->
             tc_unload_module_with_bg_traffic
         ]},
         {release, [sequence], [
-            tc_release_package_contract
+            tc_release_package_contract,
+            tc_same_version_load_delete_purge_no_thread_growth
         ]}
     ].
 
@@ -158,7 +159,8 @@ all() ->
                 tc_application_upgrade,
                 tc_upgrade_with_traffic,
                 tc_unload_module_with_bg_traffic,
-                tc_release_package_contract
+                tc_release_package_contract,
+                tc_same_version_load_delete_purge_no_thread_growth
             ],
     LocalTcs ++ [{group, old_to_current}, {group, release}].
 
@@ -351,7 +353,7 @@ tc_upgrade_with_traffic(Config) ->
         ?assertEqual(false, rpc_call(Node, code, purge, [quicer_nif])),
         %% THEN: no old code for quicer_nif
         ?assertEqual(false, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
-        ?assertEqual(OldNoThreads, rpc_call(Node, ?MODULE, no_threads, [])),
+        ?assert(rpc_call(Node, ?MODULE, no_threads, []) =< NewNoThreads),
         case UpgradeResult of
             {ok, _UpgradeInfo} ->
                 assert_remote_alive(Node);
@@ -415,6 +417,15 @@ tc_release_package_contract(Config) ->
     ok = assert_old_nif_present(ReleasePriv),
     with_slave(Config, fun(Node) ->
         ok = rpc_call(Node, ?MODULE, slave_load_release_nif, [ReleaseAppDir]),
+        assert_remote_alive(Node),
+        ok
+    end).
+
+tc_same_version_load_delete_purge_no_thread_growth(Config) ->
+    with_slave(Config, fun(Node) ->
+        ok = rpc_call(Node, ?MODULE, slave_same_version_load_delete_purge, [
+            current_app_dir(Config), 10
+        ]),
         assert_remote_alive(Node),
         ok
     end).
@@ -939,6 +950,53 @@ slave_load_release_nif(ReleaseAppDir) ->
     ReleasePriv = code:priv_dir(quicer),
     ok.
 
+slave_same_version_load_delete_purge(AppDir, Times) ->
+    Ebin = filename:join(AppDir, "ebin"),
+    ok = add_patha(Ebin),
+    BaselineThreads = no_threads(),
+    io:format("same-version reload baseline threads: ~p~n", [BaselineThreads]),
+    lists:foreach(
+        fun(I) ->
+            ok = slave_load_delete_purge_once(Ebin),
+            Threads = wait_thread_count_at_most(BaselineThreads, 2000),
+            io:format("same-version reload iteration ~p threads: ~p~n", [I, Threads]),
+            case Threads =< BaselineThreads of
+                true -> ok;
+                false -> exit({thread_count_increased, I, BaselineThreads, Threads})
+            end
+        end,
+        lists:seq(1, Times)
+    ),
+    ?assertEqual(false, erlang:check_old_code(quicer_nif)),
+    ?assertEqual(BaselineThreads, no_threads()),
+    ok.
+
+wait_thread_count_at_most(MaxThreads, Timeout) ->
+    Sleep = 100,
+    Attempts = max(1, Timeout div Sleep),
+    wait_thread_count_at_most(MaxThreads, Attempts, Sleep, no_threads()).
+
+wait_thread_count_at_most(MaxThreads, _Attempts, _Sleep, Threads) when Threads =< MaxThreads ->
+    Threads;
+wait_thread_count_at_most(_MaxThreads, 0, _Sleep, Threads) ->
+    Threads;
+wait_thread_count_at_most(MaxThreads, Attempts, Sleep, _Threads) ->
+    timer:sleep(Sleep),
+    wait_thread_count_at_most(MaxThreads, Attempts - 1, Sleep, no_threads()).
+
+slave_load_delete_purge_once(Ebin) ->
+    slave_purge_quicer_modules(),
+    ok = add_patha(Ebin),
+    ok = ensure_quicer_loaded(),
+    {ok, _} = application:ensure_all_started(quicer),
+    ok = assert_module_loaded_from(quicer_nif, Ebin),
+    _ = application:stop(quicer),
+    _ = application:unload(quicer),
+    _ = code:delete(quicer_nif),
+    _ = code:purge(quicer_nif),
+    false = erlang:check_old_code(quicer_nif),
+    ok.
+
 slave_upgrade_nif(CurrentAppDir, _OldAppDir) ->
     CurrentEbin = filename:join(CurrentAppDir, "ebin"),
     ok = add_patha(CurrentEbin),
@@ -1338,14 +1396,12 @@ slave_assert_ping(Stream, Payload) ->
 
 -spec no_threads() -> integer().
 no_threads() ->
-    ["Threads:", X] =
-        string:tokens(
-            os:cmd(
-                io_lib:format(
-                    "grep Thread /proc/~s/status",
-                    [os:getpid()]
-                )
-            ),
-            "\t\n"
-        ),
-    list_to_integer(X).
+    StatusFile = filename:join(["/proc", os:getpid(), "status"]),
+    {ok, Status} = file:read_file(StatusFile),
+    [ThreadsLine] = [
+        Line
+     || Line <- string:split(binary_to_list(Status), "\n", all),
+        lists:prefix("Threads:", Line)
+    ],
+    ["Threads:", Count] = string:tokens(ThreadsLine, "\t "),
+    list_to_integer(Count).

--- a/test/quicer_upgrade_SUITE.erl
+++ b/test/quicer_upgrade_SUITE.erl
@@ -16,16 +16,29 @@
 -module(quicer_upgrade_SUITE).
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
+-include_lib("quicer/include/quicer.hrl").
+
+-import(quicer_test_lib, [
+    default_conn_opts/0,
+    default_listen_opts/1,
+    select_free_port/1
+]).
+
+-define(DEFAULT_OLD_VERSION, "0.2.5").
+-define(HTTP_TIMEOUT, 120000).
+-define(SLAVE_TIMEOUT, 40000).
 %%--------------------------------------------------------------------
 %% @spec suite() -> Info
 %% Info = [tuple()]
 %% @end
 %%--------------------------------------------------------------------
 suite() ->
-    [{timetrap, {seconds, 30}}].
+    [{timetrap, {minutes, 1}}].
 
 %%--------------------------------------------------------------------
 %% @spec init_per_suite(Config0) ->
@@ -37,7 +50,12 @@ suite() ->
 init_per_suite(Config) ->
     %% close all listeners under global registration
     [quicer:close_listener(L, 1000) || L <- quicer:get_listeners()],
-    Config.
+    quicer_test_lib:generate_tls_certs(Config),
+    try prepare_upgrade_dirs(Config) of
+        Config1 -> Config1
+    catch
+        throw:{skip, Reason} -> {skip, Reason}
+    end.
 
 %%--------------------------------------------------------------------
 %% @spec end_per_suite(Config0) -> term() | {save_config,Config1}
@@ -110,7 +128,18 @@ end_per_testcase(_TestCase, _Config) ->
 %% @end
 %%--------------------------------------------------------------------
 groups() ->
-    [].
+    [
+        {old_to_current, [sequence], [
+            tc_upgrade_basic_nif_reload,
+            tc_upgrade_soft_and_hard_purge,
+            tc_application_upgrade,
+            tc_upgrade_with_traffic,
+            tc_unload_module_with_bg_traffic
+        ]},
+        {release, [sequence], [
+            tc_release_package_contract
+        ]}
+    ].
 
 %%--------------------------------------------------------------------
 %% @spec all() -> GroupsAndTestCases | {skip,Reason}
@@ -121,7 +150,17 @@ groups() ->
 %% @end
 %%--------------------------------------------------------------------
 all() ->
-    quicer_test_lib:all_tcs(?MODULE).
+    LocalTcs =
+        quicer_test_lib:all_tcs(?MODULE) --
+            [
+                tc_upgrade_basic_nif_reload,
+                tc_upgrade_soft_and_hard_purge,
+                tc_application_upgrade,
+                tc_upgrade_with_traffic,
+                tc_unload_module_with_bg_traffic,
+                tc_release_package_contract
+            ],
+    LocalTcs ++ [{group, old_to_current}, {group, release}].
 
 %%--------------------------------------------------------------------
 %% @spec TestCase(Config0) ->
@@ -217,6 +256,169 @@ tc_nif_module_upgrade_fail_dueto_mismatch_abiversion(_Config) ->
     %% Then quicer_nif should still be loaded
     ?assertMatch({file, _}, code:is_loaded(quicer_nif)).
 
+tc_upgrade_basic_nif_reload(Config) ->
+    with_slave(Config, fun(Node) ->
+        %% GIVEN: slave runs old vsn quicer
+        OldPriv = rpc_call(Node, ?MODULE, slave_load_old_quicer, []),
+        assert_remote_alive(Node),
+        ?assertEqual(old_priv_dir(Config), OldPriv),
+        %% WHEN: slave is called to upgrade the NIF.
+        {ok, Info} = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_nif,
+            [current_app_dir(Config), old_app_dir(Config)]
+        ),
+        assert_remote_alive(Node),
+        ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, Info)),
+        ?assertEqual(1, maps:get(abi_version, Info)),
+        %% THEN: 'old' code exists
+        true = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        ok
+    end).
+
+tc_upgrade_soft_and_hard_purge(Config) ->
+    with_slave(Config, fun(Node) ->
+        _ = rpc_call(Node, ?MODULE, slave_load_old_quicer, []),
+        {ok, _Info} = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_nif,
+            [current_app_dir(Config), old_app_dir(Config)]
+        ),
+        %% GIVEN: slave runs new code but also has old code
+        true = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        %% WHEN: *soft* purge old code success
+        true = rpc_call(Node, code, soft_purge, [quicer_nif]),
+        %% THEN: NO old code.
+        false = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        assert_remote_alive(Node),
+        %% WHEN: slave load New code (same vsn) and then *hard* purge
+        {module, quicer_nif} = rpc_call(Node, code, load_file, [quicer_nif]),
+        _ = rpc_call(Node, code, purge, [quicer_nif]),
+        %% THEN: old code is purged.
+        false = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        assert_remote_alive(Node),
+        ok
+    end).
+
+tc_application_upgrade(Config) ->
+    with_slave(Config, fun(Node) ->
+        %% GIVEN: when slave rus old vsn app
+        {ok, OldVsn} = rpc_call(Node, ?MODULE, slave_start_old_application, []),
+        ?assertEqual(old_version(Config), OldVsn),
+        %% WHEN: upgrade app with release handler
+        {ok, UpgradeInfo} = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_application,
+            [current_app_dir(Config), old_app_dir(Config)]
+        ),
+        assert_remote_alive(Node),
+        %% THEN: app vsn is switched to new
+        ?assertEqual(current_version(Config), maps:get(vsn, UpgradeInfo)),
+        ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, UpgradeInfo)),
+        ok
+    end).
+
+tc_upgrade_with_traffic(Config) ->
+    with_slave(Config, fun(Node) ->
+        Port = select_free_port(quic),
+        {ok, OldVsn} = rpc_call(Node, ?MODULE, slave_start_old_application, []),
+        OldNoThreads = rpc_call(Node, ?MODULE, no_threads, []),
+        %% GIVEN: slave node is running traffic
+        ?assertEqual(OldVsn, old_version()),
+        {ok, Pair} = rpc_call(Node, ?MODULE, slave_start_ping_pair, [Config, Port]),
+        %% WHEN: we load new vsn of code
+        UpgradeResult = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_nif_with_timeout,
+            [current_app_dir(Config), old_app_dir(Config), 5000]
+        ),
+        ct:pal("upgrade-with-traffic NIF reload result: ~p", [UpgradeResult]),
+        timer:sleep(1000),
+        NewNoThreads = rpc_call(Node, ?MODULE, no_threads, []),
+
+        assert_remote_alive(Node),
+        %% THEN: old code is still in use and new code spawn more worker treads
+        ?assertEqual(true, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
+        ?assertEqual(NewNoThreads, OldNoThreads + erlang:system_info(schedulers)),
+        %% WHEN: we purge the code after stopped the traffic and the listener.
+        ok = rpc_call(Node, ?MODULE, slave_stop_ping_pair, [Pair]),
+        ct:pal("rpc slave_stop_ping_pair ok"),
+        %% THEN: purge success and no killed process.
+        ?assertEqual(false, rpc_call(Node, code, purge, [quicer_nif])),
+        %% THEN: no old code for quicer_nif
+        ?assertEqual(false, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
+        ?assertEqual(OldNoThreads, rpc_call(Node, ?MODULE, no_threads, [])),
+        case UpgradeResult of
+            {ok, _UpgradeInfo} ->
+                assert_remote_alive(Node);
+            {timeout, _Pid} ->
+                assert_remote_alive(Node)
+        end,
+        ok
+    end).
+
+tc_unload_module_with_bg_traffic(Config) ->
+    with_slave(Config, fun(Node) ->
+        Port = select_free_port(quic),
+        {ok, OldVsn} = rpc_call(Node, ?MODULE, slave_start_old_application, []),
+        ?assertEqual(OldVsn, old_version()),
+        %% GIVE: quicer is running traffic with old version
+        {ok, Pair} = rpc_call(Node, ?MODULE, slave_start_ping_pair, [Config, Port]),
+        ?assertEqual(false, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
+        {ok, BgTraffic} = rpc_call(Node, ?MODULE, slave_start_bg_ping_traffic, [Pair]),
+        timer:sleep(1000),
+        %% WHEN: unload the quicer nif.
+        UnloadResult = rpc_call(Node, code, delete, [quicer_nif]),
+        ct:pal("module delete while traffic running result: ~p", [UnloadResult]),
+        assert_remote_alive(Node),
+        %% THEN: quicer nif is unloaded but old process is lingering with old code.
+        ?assertEqual(true, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
+        %% WHEN: we start new pair of the traffic
+        ok = rpc_call(Node, ?MODULE, slave_ping_pair, [Pair, <<"after-unload">>]),
+        %% THEN: we have co-exists new & old code but same copy
+        ?assertEqual(true, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
+        ?assertNotEqual(false, rpc_call(Node, code, is_loaded, [quicer_nif])),
+        ok = rpc_call(Node, ?MODULE, slave_stop_bg_ping_traffic, [BgTraffic]),
+        ok = rpc_call(Node, ?MODULE, slave_stop_ping_pair, [Pair]),
+        ok
+    end).
+
+%% verifies that a release-style prebuilt NIF package can be created,
+%%        checksummed, extracted, and loaded from a separate quicer app directory
+%%        on a peer node
+tc_release_package_contract(Config) ->
+    PackageDir = filename:join(?config(priv_dir, Config), "release_package"),
+    PackageSrc = filename:join(PackageDir, "src"),
+    ReleaseAppDir = filename:join([PackageDir, "release_app", "quicer"]),
+    ReleaseEbin = filename:join(ReleaseAppDir, "ebin"),
+    ReleasePriv = filename:join(ReleaseAppDir, "priv"),
+    PackageName = release_nif_asset_name(env_or_default("QUICER_VERSION", current_version(Config))),
+    Package = filename:join(PackageDir, PackageName),
+    Sha256File = Package ++ ".sha256",
+    ok = ensure_clean_dir(PackageDir),
+    ok = filelib:ensure_dir(filename:join(PackageSrc, "dummy")),
+    ok = filelib:ensure_dir(filename:join(ReleaseEbin, "dummy")),
+    ok = filelib:ensure_dir(filename:join(ReleasePriv, "dummy")),
+    ok = copy_dir_files(filename:join(current_app_dir(Config), "ebin"), ReleaseEbin),
+    StagedNif = filename:join(PackageSrc, "libquicer_nif.so"),
+    ok = copy_file(current_nif_file(), StagedNif),
+    ok = create_nif_release_package(Package, StagedNif),
+    Sha256 = sha256_hex(Package),
+    ok = file:write_file(Sha256File, [Sha256, $\n]),
+    {ok, WrittenSha256} = file:read_file(Sha256File),
+    ?assertEqual(Sha256, string:trim(binary_to_list(WrittenSha256))),
+    ok = erl_tar:extract(Package, [compressed, {cwd, ReleasePriv}]),
+    ok = assert_old_nif_present(ReleasePriv),
+    with_slave(Config, fun(Node) ->
+        ok = rpc_call(Node, ?MODULE, slave_load_release_nif, [ReleaseAppDir]),
+        assert_remote_alive(Node),
+        ok
+    end).
+
 %% Helpers
 
 %% @doc ensure neither old nor new code is present
@@ -235,3 +437,915 @@ ensure_module_current_vsn(Module) ->
     ensure_module_no_code(Module),
     _ = code:load_file(Module),
     ok.
+
+%% Upgrade fixture setup
+
+prepare_upgrade_dirs(Config) ->
+    OldVersion = old_version(),
+    PrivDir = ?config(priv_dir, Config),
+    WorkDir = filename:join(PrivDir, "upgrade"),
+    OldAppDir = filename:join([WorkDir, "old", "quicer"]),
+    CurrentAppDir = filename:join([WorkDir, "current", "quicer"]),
+    ok = ensure_clean_dir(WorkDir),
+    ok = prepare_current_app_dir(CurrentAppDir),
+    ok = prepare_old_app_dir(OldVersion, WorkDir, OldAppDir),
+    OldApp = read_app_file(filename:join([OldAppDir, "ebin", "quicer.app"])),
+    CurrentApp = read_app_file(filename:join([CurrentAppDir, "ebin", "quicer.app"])),
+    OldVsn = app_vsn(OldApp),
+    CurrentVsn = app_vsn(CurrentApp),
+    ok = write_appup(OldAppDir, OldVsn, CurrentVsn, []),
+    ok = write_appup(CurrentAppDir, CurrentVsn, OldVsn, current_modules(CurrentApp)),
+    ct:pal("quicer upgrade fixture old_version=~s current_version=~s old_dir=~s current_dir=~s", [
+        OldVsn, CurrentVsn, OldAppDir, CurrentAppDir
+    ]),
+    [
+        {upgrade_work_dir, WorkDir},
+        {old_quicer_version, OldVsn},
+        {old_quicer_app_dir, OldAppDir},
+        {current_quicer_version, CurrentVsn},
+        {current_quicer_app_dir, CurrentAppDir}
+        | Config
+    ].
+
+prepare_current_app_dir(CurrentAppDir) ->
+    Ebin = filename:join(CurrentAppDir, "ebin"),
+    Priv = filename:join(CurrentAppDir, "priv"),
+    ok = ensure_clean_dir(CurrentAppDir),
+    ok = filelib:ensure_dir(filename:join(Ebin, "dummy")),
+    ok = filelib:ensure_dir(filename:join(Priv, "dummy")),
+    CurrentEbin = code:lib_dir(quicer, ebin),
+    ok = copy_dir_files(CurrentEbin, Ebin),
+    Nif = current_nif_file(),
+    ok = copy_file(Nif, filename:join(Priv, filename:basename(Nif))),
+    case filename:basename(Nif) of
+        "libquicer_nif.so" ->
+            ok;
+        _ ->
+            ok = copy_file(Nif, filename:join(Priv, "libquicer_nif.so"))
+    end,
+    ok.
+
+prepare_old_app_dir(OldVersion, WorkDir, OldAppDir) ->
+    Downloads = filename:join(WorkDir, "downloads"),
+    SourceRoot = filename:join(WorkDir, "old_source"),
+    OldEbin = filename:join(OldAppDir, "ebin"),
+    OldPriv = filename:join(OldAppDir, "priv"),
+    ok = filelib:ensure_dir(filename:join(Downloads, "dummy")),
+    ok = ensure_clean_dir(OldAppDir),
+    ok = filelib:ensure_dir(filename:join(OldEbin, "dummy")),
+    ok = filelib:ensure_dir(filename:join(OldPriv, "dummy")),
+    SourceDir = fetch_old_source(OldVersion, Downloads, SourceRoot),
+    ok = compile_old_beams(SourceDir, OldEbin),
+    ok = write_old_app(SourceDir, OldEbin, OldVersion),
+    ok = fetch_old_nif(OldVersion, Downloads, OldPriv),
+    ok.
+
+old_version() ->
+    env_or_default("QUICER_UPGRADE_FROM_VERSION", ?DEFAULT_OLD_VERSION).
+
+old_version(Config) ->
+    ?config(old_quicer_version, Config).
+
+current_version(Config) ->
+    ?config(current_quicer_version, Config).
+
+old_app_dir(Config) ->
+    ?config(old_quicer_app_dir, Config).
+
+current_app_dir(Config) ->
+    ?config(current_quicer_app_dir, Config).
+
+old_priv_dir(Config) ->
+    filename:join(old_app_dir(Config), "priv").
+
+current_priv_dir(Config) ->
+    filename:join(current_app_dir(Config), "priv").
+
+env_or_default(Name, Default) ->
+    case os:getenv(Name) of
+        false -> Default;
+        "" -> Default;
+        Value -> Value
+    end.
+
+fetch_old_source(OldVersion, Downloads, SourceRoot) ->
+    SourceTar = filename:join(Downloads, "quicer-" ++ OldVersion ++ ".tar.gz"),
+    SourceUrls = source_urls(OldVersion),
+    ok = download_first(SourceUrls, SourceTar),
+    ok = ensure_clean_dir(SourceRoot),
+    ok = erl_tar:extract(SourceTar, [compressed, {cwd, SourceRoot}]),
+    [Dir] = filelib:wildcard(filename:join(SourceRoot, "*")),
+    Dir.
+
+source_urls(OldVersion) ->
+    Tags =
+        case string:prefix(OldVersion, "v") of
+            nomatch -> [OldVersion, "v" ++ OldVersion];
+            _ -> [OldVersion]
+        end,
+    ["https://github.com/emqx/quic/archive/refs/tags/" ++ Tag ++ ".tar.gz" || Tag <- Tags].
+
+fetch_old_nif(OldVersion, Downloads, OldPriv) ->
+    GzFile = filename:join(Downloads, old_nif_asset_name(OldVersion)),
+    {IsExactUrl, Urls} =
+        case os:getenv("QUICER_UPGRADE_FROM_URL") of
+            false -> {false, old_nif_urls(OldVersion)};
+            "" -> {false, old_nif_urls(OldVersion)};
+            Url -> {true, [Url]}
+        end,
+    case download_first_result(Urls, GzFile) of
+        ok ->
+            ok;
+        {error, Reasons} when IsExactUrl ->
+            ct:fail({download_failed, GzFile, lists:reverse(Reasons)});
+        {error, Reasons} ->
+            throw(
+                {skip,
+                    {old_prebuilt_nif_not_available, old_nif_asset_name(OldVersion),
+                        lists:reverse(Reasons)}}
+            )
+    end,
+    ok = unpack_old_nif(GzFile, OldPriv),
+    ok = assert_old_nif_present(OldPriv).
+
+unpack_old_nif(GzFile, OldPriv) ->
+    case erl_tar:extract(GzFile, [compressed, {cwd, OldPriv}]) of
+        ok ->
+            ok;
+        {error, _Reason} ->
+            {ok, GzBin} = file:read_file(GzFile),
+            NifBin = zlib:gunzip(GzBin),
+            ok = file:write_file(filename:join(OldPriv, "libquicer_nif.so"), NifBin)
+    end.
+
+assert_old_nif_present(OldPriv) ->
+    case filelib:is_file(filename:join(OldPriv, "libquicer_nif.so")) of
+        true -> ok;
+        false -> ct:fail({old_nif_not_found_after_unpack, OldPriv})
+    end.
+
+old_nif_urls(OldVersion) ->
+    Asset = old_nif_asset_name(OldVersion),
+    Tags =
+        case string:prefix(OldVersion, "v") of
+            nomatch -> [OldVersion, "v" ++ OldVersion];
+            _ -> [OldVersion]
+        end,
+    ["https://github.com/emqx/quic/releases/download/" ++ Tag ++ "/" ++ Asset || Tag <- Tags].
+
+old_nif_asset_name(OldVersion) ->
+    lists:flatten(
+        io_lib:format(
+            "libquicer-~s-otp~s-~s-~s-~s.gz",
+            [
+                OldVersion,
+                erlang:system_info(otp_release),
+                quicer_upgrade_openssl(),
+                package_system(),
+                package_arch()
+            ]
+        )
+    ).
+
+release_nif_asset_name(Version) ->
+    lists:flatten(
+        io_lib:format(
+            "libquicer-~s-otp~s-~s-~s-~s.gz",
+            [
+                Version,
+                erlang:system_info(otp_release),
+                env_or_default("QUICER_TLS_VER", "openssl"),
+                package_system(),
+                package_arch()
+            ]
+        )
+    ).
+
+quicer_upgrade_openssl() ->
+    case os:getenv("QUICER_UPGRADE_OPENSSL") of
+        false -> package_openssl_name(env_or_default("QUICER_TLS_VER", "openssl"));
+        "" -> package_openssl_name(env_or_default("QUICER_TLS_VER", "openssl"));
+        Value -> Value
+    end.
+
+package_openssl_name("sys") -> "sys";
+package_openssl_name("openssl3") -> "openssl3";
+package_openssl_name(_BundledOpenSSL) -> "openssl".
+
+package_arch() ->
+    string:trim(os:cmd("uname -m")).
+
+package_system() ->
+    case os:type() of
+        {unix, darwin} ->
+            Major = string:trim(os:cmd("sw_vers -productVersion | cut -d. -f1")),
+            "macos" ++ Major;
+        {unix, linux} ->
+            linux_package_system();
+        Other ->
+            ct:fail({unsupported_upgrade_os, Other})
+    end.
+
+linux_package_system() ->
+    {ok, Bin} = file:read_file("/etc/os-release"),
+    Lines = string:split(binary_to_list(Bin), "\n", all),
+    Id = os_release_value("ID", Lines),
+    VersionId = os_release_value("VERSION_ID", Lines),
+    strip_linux_suffix(Id ++ VersionId).
+
+os_release_value(Key, Lines) ->
+    Prefix = Key ++ "=",
+    case
+        [
+            strip_quotes(string:trim(string:substr(Line, length(Prefix) + 1)))
+         || Line <- Lines,
+            lists:prefix(Prefix, Line)
+        ]
+    of
+        [Value | _] -> Value;
+        [] -> ""
+    end.
+
+strip_quotes([$" | Rest]) ->
+    lists:reverse(strip_leading_quote(lists:reverse(Rest)));
+strip_quotes(Value) ->
+    Value.
+
+strip_leading_quote([$" | Rest]) -> Rest;
+strip_leading_quote(Value) -> Value.
+
+strip_linux_suffix(System) ->
+    case string:chr(System, $-) of
+        0 ->
+            System;
+        Pos ->
+            {Letters, _} = lists:splitwith(
+                fun(C) ->
+                    (C >= $a andalso C =< $z) orelse
+                        (C >= $A andalso C =< $Z)
+                end,
+                string:slice(System, 0, Pos - 1)
+            ),
+            Letters
+    end.
+
+download_first(Urls, Target) ->
+    case download_first_result(Urls, Target) of
+        ok ->
+            ok;
+        {error, Reasons} ->
+            ct:fail({download_failed, Target, lists:reverse(Reasons)})
+    end.
+
+download_first_result(Urls, Target) ->
+    download_first(Urls, Target, []).
+
+download_first([], _Target, Reasons) ->
+    {error, Reasons};
+download_first([Url | Rest], Target, Reasons) ->
+    ct:pal("download ~s to ~s", [Url, Target]),
+    case download(Url, Target) of
+        ok -> ok;
+        {error, Reason} -> download_first(Rest, Target, [{Url, Reason} | Reasons])
+    end.
+
+download(Url, Target) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(inets),
+    Headers = [{"user-agent", "quicer-upgrade-suite"}],
+    HttpOptions = [{autoredirect, true}, {timeout, ?HTTP_TIMEOUT}],
+    Options = [{body_format, binary}],
+    case httpc:request(get, {Url, Headers}, HttpOptions, Options) of
+        {ok, {{_, 200, _}, _RespHeaders, Body}} ->
+            file:write_file(Target, Body);
+        {ok, {{_, Status, ReasonPhrase}, _RespHeaders, Body}} ->
+            {error, {http_status, Status, ReasonPhrase, byte_size(Body)}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+compile_old_beams(SourceDir, OldEbin) ->
+    Include = filename:join(SourceDir, "include"),
+    SrcFiles = filelib:wildcard(filename:join([SourceDir, "src", "*.erl"])),
+    Results = [
+        compile:file(Src, [
+            report,
+            {i, Include},
+            {outdir, OldEbin}
+        ])
+     || Src <- SrcFiles
+    ],
+    case [Error || Error <- Results, not is_compile_ok(Error)] of
+        [] -> ok;
+        Errors -> ct:fail({old_source_compile_failed, Errors})
+    end.
+
+is_compile_ok({ok, _Module}) -> true;
+is_compile_ok({ok, _Module, _Warnings}) -> true;
+is_compile_ok(_) -> false.
+
+write_old_app(SourceDir, OldEbin, OldVersion) ->
+    AppSrc = filename:join([SourceDir, "src", "quicer.app.src"]),
+    App = read_app_file(AppSrc),
+    Modules = compiled_modules(OldEbin),
+    App1 = set_app_props(App, [
+        {vsn, OldVersion},
+        {modules, Modules}
+    ]),
+    write_term_file(filename:join(OldEbin, "quicer.app"), App1).
+
+write_appup(AppDir, ToVsn, FromVsn, Modules) ->
+    Instructions = appup_instructions(Modules),
+    Appup = {ToVsn, [{FromVsn, Instructions}], [{FromVsn, Instructions}]},
+    write_term_file(filename:join([AppDir, "ebin", "quicer.appup"]), Appup).
+
+appup_instructions([]) ->
+    [];
+appup_instructions(Modules) ->
+    [{load_module, Module} || Module <- Modules].
+
+read_app_file(File) ->
+    {ok, [App]} = file:consult(File),
+    App.
+
+app_vsn({application, quicer, Props}) ->
+    proplists:get_value(vsn, Props).
+
+current_modules({application, quicer, Props}) ->
+    [
+        Module
+     || Module <- proplists:get_value(modules, Props, []), lists:member(Module, quicer_modules())
+    ].
+
+compiled_modules(Ebin) ->
+    lists:sort([
+        list_to_atom(filename:basename(Beam, ".beam"))
+     || Beam <- filelib:wildcard(filename:join(Ebin, "*.beam"))
+    ]).
+
+set_app_props({application, quicer, Props}, Updates) ->
+    {application, quicer, lists:foldl(fun set_app_prop/2, Props, Updates)}.
+
+set_app_prop({Key, Value}, Props) ->
+    lists:keystore(Key, 1, Props, {Key, Value}).
+
+write_term_file(File, Term) ->
+    file:write_file(File, io_lib:format("~p.~n", [Term])).
+
+create_nif_release_package(Package, NifFile) ->
+    {ok, Tar} = erl_tar:open(Package, [write, compressed]),
+    ok = erl_tar:add(Tar, NifFile, "libquicer_nif.so", []),
+    ok = erl_tar:close(Tar).
+
+sha256_hex(File) ->
+    {ok, Bin} = file:read_file(File),
+    lists:flatten([io_lib:format("~2.16.0b", [Byte]) || <<Byte>> <= crypto:hash(sha256, Bin)]).
+
+current_nif_file() ->
+    Candidates = [
+        filename:join(code:priv_dir(quicer), "libquicer_nif.so"),
+        filename:join(["c_build", "priv", "libquicer_nif.so"])
+    ],
+    case [Path || Path <- Candidates, filelib:is_file(Path)] of
+        [Path | _] -> Path;
+        [] -> ct:fail({current_nif_not_found, Candidates})
+    end.
+
+copy_dir_files(From, To) ->
+    {ok, Files} = file:list_dir(From),
+    lists:foreach(
+        fun(File) ->
+            Src = filename:join(From, File),
+            Dst = filename:join(To, File),
+            case file:read_file_info(Src) of
+                {ok, #file_info{type = regular}} ->
+                    ok = copy_file(Src, Dst);
+                {ok, #file_info{type = directory}} ->
+                    ok = ensure_clean_dir(Dst),
+                    ok = copy_dir_files(Src, Dst);
+                {ok, _} ->
+                    ok;
+                {error, Reason} ->
+                    ct:fail({copy_failed, Src, Reason})
+            end
+        end,
+        Files
+    ),
+    ok.
+
+copy_file(Src, Dst) ->
+    case file:copy(Src, Dst) of
+        {ok, _Bytes} -> ok;
+        {error, Reason} -> ct:fail({copy_failed, Src, Dst, Reason})
+    end.
+
+ensure_clean_dir(Dir) ->
+    _ = file:del_dir_r(Dir),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")).
+
+%% Slave control
+
+with_slave(Config, Fun) ->
+    {ok, Peer, Node} = start_upgrade_peer(Config),
+    try
+        Fun(Node)
+    after
+        ct:pal("stopping peer ~p on node ~p state=~p", [Peer, Node, catch peer:get_state(Peer)]),
+        catch peer:stop(Peer)
+    end.
+
+start_upgrade_peer(Config) ->
+    ok = ensure_distributed_master(),
+    Name = upgrade_slave_name(),
+    {ok, Peer, Node} = peer:start_link(#{
+        name => Name,
+        wait_boot => 30000,
+        shutdown => {halt, 5000}
+    }),
+    OldEbin = filename:join(old_app_dir(Config), "ebin"),
+    TestEbin = filename:dirname(code:which(?MODULE)),
+    TestLibEbin = filename:dirname(code:which(quicer_test_lib)),
+    ok = rpc_add_path(Node, add_patha, OldEbin),
+    ok = rpc_add_path(Node, add_pathz, TestEbin),
+    ok = rpc_add_path(Node, add_pathz, TestLibEbin),
+    {module, ?MODULE} = rpc_call(Node, code, load_file, [?MODULE]),
+    {module, quicer_test_lib} = rpc_call(Node, code, load_file, [quicer_test_lib]),
+    {ok, Peer, Node}.
+
+upgrade_slave_name() ->
+    Suffix = lists:flatten(
+        io_lib:format("~B_~B", [
+            erlang:system_time(millisecond),
+            erlang:unique_integer([positive])
+        ])
+    ),
+    list_to_atom("quicer_upgrade_" ++ Suffix).
+
+rpc_add_path(Node, Fun, Path) ->
+    case rpc_call(Node, code, Fun, [Path]) of
+        true -> ok;
+        ok -> ok;
+        {error, Reason} -> ct:fail({add_code_path_failed, Node, Path, Reason})
+    end.
+
+ensure_distributed_master() ->
+    case node() of
+        nonode@nohost ->
+            Name = list_to_atom(
+                "quicer_ct_master_" ++ integer_to_list(erlang:unique_integer([positive]))
+            ),
+            case net_kernel:start([Name, shortnames]) of
+                {ok, _Pid} -> ok;
+                {error, {{already_started, _Pid}, _}} -> ok;
+                {error, Reason} -> ct:fail({failed_to_start_distribution, Reason})
+            end;
+        _Node ->
+            ok
+    end.
+
+rpc_call(Node, M, F, A) ->
+    rpc_call(Node, M, F, A, ?SLAVE_TIMEOUT).
+rpc_call(Node, M, F, A, Timeout) ->
+    case rpc:call(Node, M, F, A, Timeout) of
+        {badrpc, Reason} ->
+            ct:fail({rpc_failed, Node, M, F, A, Reason});
+        Result ->
+            Result
+    end.
+
+assert_remote_alive(Node) ->
+    pong = net_adm:ping(Node),
+    true = rpc_call(Node, erlang, is_alive, []),
+    ok.
+
+%% Functions executed on the slave node.
+
+slave_load_old_quicer() ->
+    slave_purge_quicer_modules(),
+    ok = ensure_quicer_loaded(),
+    {ok, _} = application:ensure_all_started(quicer),
+    OldEbin = code:lib_dir(quicer, ebin),
+    ok = assert_module_loaded_from(quicer_nif, OldEbin),
+    code:priv_dir(quicer).
+
+slave_load_release_nif(ReleaseAppDir) ->
+    slave_purge_quicer_modules(),
+    ReleaseEbin = filename:join(ReleaseAppDir, "ebin"),
+    ReleasePriv = filename:join(ReleaseAppDir, "priv"),
+    ok = add_patha(ReleaseEbin),
+    ok = ensure_quicer_loaded(),
+    {ok, _} = application:ensure_all_started(quicer),
+    ok = assert_module_loaded_from(quicer_nif, ReleaseEbin),
+    ReleasePriv = code:priv_dir(quicer),
+    ok.
+
+slave_upgrade_nif(CurrentAppDir, _OldAppDir) ->
+    CurrentEbin = filename:join(CurrentAppDir, "ebin"),
+    ok = add_patha(CurrentEbin),
+    case code:load_file(quicer_nif) of
+        {module, quicer_nif} -> ok;
+        {error, not_purged} -> ok
+    end,
+    ok = assert_module_loaded_from(quicer_nif, CurrentEbin),
+    {ok, #{
+        priv_dir => code:priv_dir(quicer),
+        abi_version => quicer:abi_version(),
+        loaded => code:is_loaded(quicer_nif)
+    }}.
+
+slave_upgrade_nif_with_timeout(CurrentAppDir, OldAppDir, Timeout) ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+        Parent ! {self(), catch slave_upgrade_nif(CurrentAppDir, OldAppDir)}
+    end),
+    receive
+        {Pid, {'EXIT', Reason}} ->
+            {error, Reason};
+        {Pid, Result} ->
+            Result
+    after Timeout ->
+        exit(Pid, kill),
+        {timeout, Pid}
+    end.
+
+slave_start_old_application() ->
+    slave_purge_quicer_modules(),
+    ok = ensure_quicer_loaded(),
+    {ok, _} = application:ensure_all_started(quicer),
+    {ok, Vsn} = application:get_key(quicer, vsn),
+    {ok, Vsn}.
+
+slave_upgrade_application(CurrentAppDir, OldAppDir) ->
+    CurrentEbin = filename:join(CurrentAppDir, "ebin"),
+    OldEbin = filename:join(OldAppDir, "ebin"),
+    case release_handler:upgrade_app(quicer, CurrentAppDir) of
+        {ok, _Unpurged} ->
+            ok;
+        {error, {old_processes, _} = Reason} ->
+            exit(Reason);
+        {error, Reason} ->
+            exit({upgrade_app_failed, Reason})
+    end,
+    ok = add_patha(CurrentEbin),
+    ok = assert_module_loaded_from(quicer_nif, CurrentEbin),
+    ok = assert_no_modules_loaded_from(OldEbin),
+    ok = assert_no_old_code(quicer_modules()),
+    {ok, Vsn} = application:get_key(quicer, vsn),
+    {ok, #{
+        vsn => Vsn,
+        priv_dir => code:priv_dir(quicer),
+        loaded => code:is_loaded(quicer_nif)
+    }}.
+
+slave_restart_quicer() ->
+    _ = application:stop(quicer),
+    _ = application:unload(quicer),
+    application:ensure_all_started(quicer),
+    ok.
+
+assert_module_loaded_from(Module, Ebin) ->
+    Expected = filename:absname(filename:join(Ebin, atom_to_list(Module) ++ ".beam")),
+    case code:is_loaded(Module) of
+        {file, Path} ->
+            ?assertEqual(Expected, filename:absname(Path)),
+            ok;
+        Other ->
+            exit({module_not_loaded_from_expected_path, Module, Expected, Other})
+    end.
+
+assert_no_modules_loaded_from(Ebin) ->
+    OldEbin = filename:absname(Ebin),
+    Lingering = [
+        {Module, filename:absname(Path)}
+     || Module <- quicer_modules(),
+        {file, Path} <- [code:is_loaded(Module)],
+        path_in_dir(Path, OldEbin)
+    ],
+    case Lingering of
+        [] -> ok;
+        _ -> exit({old_modules_lingering, OldEbin, Lingering})
+    end.
+
+assert_no_old_code(Modules) when is_list(Modules) ->
+    Lingering = [Module || Module <- Modules, erlang:check_old_code(Module)],
+    case Lingering of
+        [] -> ok;
+        _ -> exit({old_code_lingering, Lingering})
+    end;
+assert_no_old_code(Module) ->
+    assert_no_old_code([Module]).
+
+path_in_dir(Path, Dir) ->
+    AbsPath = filename:absname(Path),
+    AbsDir = filename:absname(Dir),
+    lists:prefix(filename:join(AbsDir, ""), AbsPath).
+
+add_patha(Path) ->
+    case code:add_patha(Path) of
+        true -> ok;
+        ok -> ok;
+        {error, Reason} -> exit({add_code_path_failed, Path, Reason})
+    end.
+
+ensure_quicer_loaded() ->
+    case application:load(quicer) of
+        ok -> ok;
+        {error, {already_loaded, quicer}} -> ok;
+        {error, Reason} -> exit({load_quicer_failed, Reason})
+    end.
+
+slave_purge_quicer_modules() ->
+    _ = application:stop(quicer),
+    _ = maybe_apply(quicer, reg_close, []),
+    _ = maybe_apply(quicer, shutdown_registration, [global]),
+    _ = maybe_apply(quicer, lib_close, []),
+    _ = application:unload(quicer),
+    lists:foreach(
+        fun(Module) ->
+            _ = code:purge(Module),
+            _ = code:delete(Module),
+            _ = code:purge(Module),
+            false = code:is_loaded(Module),
+            false = erlang:check_old_code(Module)
+        end,
+        quicer_modules()
+    ),
+    ok.
+
+maybe_apply(Module, Function, Args) ->
+    case erlang:function_exported(Module, Function, length(Args)) of
+        true -> catch apply(Module, Function, Args);
+        false -> ok
+    end.
+
+quicer_modules() ->
+    [
+        quicer,
+        quicer_app,
+        quicer_conn_acceptor_sup,
+        quicer_connection,
+        quicer_lib,
+        quicer_listener,
+        quicer_listener_sup,
+        quicer_local_stream,
+        quicer_nif,
+        quicer_remote_stream,
+        quicer_server_conn_callback,
+        quicer_stream,
+        quicer_sup
+    ].
+
+slave_hold_connection_resource() ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+        Conn = quicer_nif:open_connection(),
+        Parent ! {self(), holding, Conn},
+        receive
+            release -> ok
+        after 10000 ->
+            ok
+        end
+    end),
+    receive
+        {Pid, holding, _Conn} -> Pid
+    after 5000 ->
+        exit(holder_timeout)
+    end.
+
+slave_wait_holder(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Ref, process, Pid, _Reason} -> ok
+    after 5000 ->
+        exit(holder_not_released)
+    end.
+
+slave_start_ping_pair(Config, Port) ->
+    Parent = self(),
+    Pid = spawn_link(fun() -> slave_ping_pair_controller(Parent, Config, Port) end),
+    receive
+        {Pid, ready} -> {ok, Pid};
+        {Pid, failed, Reason} -> exit(Reason)
+    after 5000 ->
+        exit(ping_pair_timeout)
+    end.
+
+slave_start_bg_ping_traffic(Pair) ->
+    Parent = self(),
+    Pid = spawn(fun() -> slave_bg_ping_traffic_loop(Parent, Pair) end),
+    receive
+        {Pid, ready} -> {ok, Pid};
+        {Pid, failed, Reason} -> exit(Reason)
+    after 5000 ->
+        exit(bg_ping_traffic_timeout)
+    end.
+
+slave_stop_bg_ping_traffic(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    Pid ! stop,
+    receive
+        {Pid, stopped} ->
+            erlang:demonitor(Ref, [flush]),
+            ok;
+        {'DOWN', Ref, process, Pid, normal} ->
+            ok;
+        {'DOWN', Ref, process, Pid, Reason} ->
+            exit({bg_ping_traffic_down, Reason})
+    after 5000 ->
+        erlang:demonitor(Ref, [flush]),
+        exit(bg_ping_traffic_stop_timeout)
+    end.
+
+slave_bg_ping_traffic_loop(Parent, Pair) ->
+    Parent ! {self(), ready},
+    slave_bg_ping_traffic_run(Parent, Pair).
+
+slave_bg_ping_traffic_run(Parent, Pair) ->
+    receive
+        stop ->
+            Parent ! {self(), stopped},
+            ok
+    after 0 ->
+        case catch slave_ping_pair(Pair, <<"bg-traffic">>) of
+            ok ->
+                timer:sleep(50),
+                slave_bg_ping_traffic_run(Parent, Pair);
+            {'EXIT', Reason} ->
+                exit({bg_ping_traffic_failed, Reason});
+            Other ->
+                exit({bg_ping_traffic_failed, Other})
+        end
+    end.
+
+slave_ping_pair(Pid, Payload) ->
+    Ref = erlang:monitor(process, Pid),
+    Pid ! {ping, self(), Ref, Payload},
+    receive
+        {Ref, Result} ->
+            erlang:demonitor(Ref, [flush]),
+            Result;
+        {'DOWN', Ref, process, Pid, Reason} ->
+            exit({ping_pair_down, Reason})
+    after 5000 ->
+        erlang:demonitor(Ref, [flush]),
+        exit({ping_pair_timeout, Payload})
+    end.
+
+slave_stop_ping_pair(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    io:format("stopping traffic pair ~p ref=~p~n", [Pid, Ref]),
+    Pid ! {stop, self(), Ref},
+    receive
+        {Ref, Result} ->
+            io:format("traffic pair stop reply ~p from ~p~n", [Result, Pid]),
+            erlang:demonitor(Ref, [flush]),
+            Result;
+        {'DOWN', Ref, process, Pid, _Reason} ->
+            io:format("traffic pair went down before stop reply ~p~n", [Pid]),
+            ok
+    after 30000 ->
+        io:format("traffic pair stop timeout ~p~n", [Pid]),
+        erlang:demonitor(Ref, [flush]),
+        exit(Pid, kill),
+        ok
+    end.
+
+slave_ping_pair_controller(Parent, Config, Port) ->
+    process_flag(trap_exit, true),
+    ListenOn = "127.0.0.1:" ++ integer_to_list(Port),
+    try
+        {ok, Listener} = quicer:listen(ListenOn, default_listen_opts(Config)),
+        Server = spawn_link(fun() -> slave_ping_server_acceptor(Listener) end),
+        {ok, Conn} = quicer:connect("127.0.0.1", Port, default_conn_opts(), 5000),
+        {ok, Stream} = quicer:start_stream(Conn, [{active, true}]),
+        ok = slave_assert_ping(Stream, <<"before-upgrade">>),
+        Parent ! {self(), ready},
+        slave_ping_pair_loop(Server, Conn, Stream)
+    catch
+        Class:Reason:Stacktrace ->
+            Parent ! {self(), failed, {Class, Reason, Stacktrace}}
+    end.
+
+slave_ping_pair_loop(Server, Conn, Stream) ->
+    receive
+        {ping, From, Ref, Payload} ->
+            From ! {Ref, slave_assert_ping(Stream, Payload)},
+            slave_ping_pair_loop(Server, Conn, Stream);
+        {stop, From, Ref} ->
+            From ! {Ref, ok},
+            slave_ping_pair_stopped();
+        {'EXIT', Server, Reason} ->
+            slave_ping_pair_loop({exited, Server, Reason}, Conn, Stream);
+        {'EXIT', _Pid, _Reason} ->
+            slave_ping_pair_loop(Server, Conn, Stream)
+    end.
+
+slave_ping_pair_stopped() ->
+    receive
+        _Any ->
+            slave_ping_pair_stopped()
+    end.
+
+slave_start_ping_server(Config, Port) ->
+    Parent = self(),
+    Pid = spawn_link(fun() -> slave_ping_server(Parent, Config, Port) end),
+    receive
+        {Pid, ready} -> {ok, Pid};
+        {Pid, failed, Reason} -> exit(Reason)
+    after 5000 ->
+        exit(listener_timeout)
+    end.
+
+slave_wait_server(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok;
+        {'DOWN', Ref, process, Pid, Reason} -> exit({server_exit, Reason})
+    after 5000 ->
+        exit(server_stop_timeout)
+    end.
+
+slave_ping_server_acceptor(Listener) ->
+    {ok, Conn} = quicer:accept(Listener, [], 5000),
+    {ok, Conn} = quicer:async_accept_stream(Conn, []),
+    {ok, Conn} = quicer:handshake(Conn),
+    receive
+        {quic, new_stream, Stream, _Props} ->
+            slave_ping_server_loop(Listener, Conn, Stream)
+    after 5000 ->
+        exit(stream_accept_timeout)
+    end.
+
+slave_ping_server(Parent, Config, Port) ->
+    ListenOn = "127.0.0.1:" ++ integer_to_list(Port),
+    case quicer:listen(ListenOn, default_listen_opts(Config)) of
+        {ok, Listener} ->
+            Parent ! {self(), ready},
+            {ok, Conn} = quicer:accept(Listener, [], 5000),
+            {ok, Conn} = quicer:async_accept_stream(Conn, []),
+            {ok, Conn} = quicer:handshake(Conn),
+            receive
+                {quic, new_stream, Stream, _Props} ->
+                    slave_ping_server_loop(Listener, Conn, Stream)
+            after 5000 ->
+                exit(stream_accept_timeout)
+            end;
+        {error, Reason} ->
+            Parent ! {self(), failed, Reason}
+    end.
+
+slave_stop_ping_pair_resources(Server, Conn, Stream) ->
+    _ = catch quicer:close_stream(Stream),
+    _ = catch quicer:close_connection(Conn),
+    catch exit(Server, shutdown),
+    timer:sleep(3000),
+    ok.
+
+slave_ping_server_loop(Listener, Conn, Stream) ->
+    receive
+        {quic, Bin, Stream, #{flags := Flags}} when is_binary(Bin) ->
+            SendFlags =
+                case (Flags band ?QUIC_RECEIVE_FLAG_FIN) > 0 of
+                    true -> ?QUICER_SEND_FLAG_SYNC bor ?QUIC_SEND_FLAG_FIN;
+                    false -> ?QUICER_SEND_FLAG_SYNC
+                end,
+            {ok, _} = quicer:send(Stream, Bin, SendFlags),
+            slave_ping_server_loop(Listener, Conn, Stream);
+        {quic, peer_send_shutdown, Stream, undefined} ->
+            ok = quicer:close_stream(Stream),
+            slave_ping_server_loop(Listener, Conn, Stream);
+        {quic, shutdown, Conn, _ErrorCode} ->
+            ok = quicer:close_connection(Conn),
+            slave_ping_server_loop(Listener, Conn, Stream);
+        stop ->
+            io:format("server loop stop"),
+            _ = quicer:close_connection(Conn),
+            _ = quicer:close_listener(Listener),
+            ok
+    end.
+
+slave_assert_ping(Stream, Payload) ->
+    case quicer:send(Stream, Payload) of
+        {ok, _} ->
+            receive
+                {quic, Payload, Stream, _Flags} -> ok
+            after 5000 ->
+                {error, {ping_timeout, Payload}}
+            end;
+        Error ->
+            {error, {send_failed, Error}}
+    end.
+
+-spec no_threads() -> integer().
+no_threads() ->
+    ["Threads:", X] =
+        string:tokens(
+            os:cmd(
+                io_lib:format(
+                    "grep Thread /proc/~s/status",
+                    [os:getpid()]
+                )
+            ),
+            "\t\n"
+        ),
+    list_to_integer(X).

--- a/test/quicer_upgrade_SUITE.erl
+++ b/test/quicer_upgrade_SUITE.erl
@@ -327,7 +327,8 @@ tc_upgrade_with_traffic(Config) ->
     with_slave(Config, fun(Node) ->
         Port = select_free_port(quic),
         {ok, OldVsn} = rpc_call(Node, ?MODULE, slave_start_old_application, []),
-        OldNoThreads = rpc_call(Node, ?MODULE, no_threads, []),
+        CheckThreads = rpc_call(Node, ?MODULE, thread_count_check_supported, []),
+        OldNoThreads = maybe_no_threads(Node, CheckThreads),
         %% GIVEN: slave node is running traffic
         ?assertEqual(OldVsn, old_version()),
         {ok, Pair} = rpc_call(Node, ?MODULE, slave_start_ping_pair, [Config, Port]),
@@ -340,12 +341,12 @@ tc_upgrade_with_traffic(Config) ->
         ),
         ct:pal("upgrade-with-traffic NIF reload result: ~p", [UpgradeResult]),
         timer:sleep(1000),
-        NewNoThreads = rpc_call(Node, ?MODULE, no_threads, []),
+        NewNoThreads = maybe_no_threads(Node, CheckThreads),
 
         assert_remote_alive(Node),
         %% THEN: old code is still in use and new code spawn more worker treads
         ?assertEqual(true, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
-        ?assertEqual(NewNoThreads, OldNoThreads + erlang:system_info(schedulers)),
+        maybe_assert_thread_growth(OldNoThreads, NewNoThreads),
         %% WHEN: we purge the code after stopped the traffic and the listener.
         ok = rpc_call(Node, ?MODULE, slave_stop_ping_pair, [Pair]),
         ct:pal("rpc slave_stop_ping_pair ok"),
@@ -353,7 +354,7 @@ tc_upgrade_with_traffic(Config) ->
         ?assertEqual(false, rpc_call(Node, code, purge, [quicer_nif])),
         %% THEN: no old code for quicer_nif
         ?assertEqual(false, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
-        ?assert(rpc_call(Node, ?MODULE, no_threads, []) =< NewNoThreads),
+        maybe_assert_thread_count_at_most(Node, CheckThreads, NewNoThreads),
         case UpgradeResult of
             {ok, _UpgradeInfo} ->
                 assert_remote_alive(Node);
@@ -929,6 +930,21 @@ assert_remote_alive(Node) ->
     true = rpc_call(Node, erlang, is_alive, []),
     ok.
 
+maybe_no_threads(Node, true) ->
+    rpc_call(Node, ?MODULE, no_threads, []);
+maybe_no_threads(_Node, false) ->
+    unsupported.
+
+maybe_assert_thread_growth(unsupported, unsupported) ->
+    ok;
+maybe_assert_thread_growth(OldNoThreads, NewNoThreads) ->
+    ?assertEqual(NewNoThreads, OldNoThreads + erlang:system_info(schedulers)).
+
+maybe_assert_thread_count_at_most(_Node, false, _MaxThreads) ->
+    ok;
+maybe_assert_thread_count_at_most(Node, true, MaxThreads) ->
+    ?assert(rpc_call(Node, ?MODULE, no_threads, []) =< MaxThreads).
+
 %% Functions executed on the slave node.
 
 slave_load_old_quicer() ->
@@ -953,21 +969,37 @@ slave_load_release_nif(ReleaseAppDir) ->
 slave_same_version_load_delete_purge(AppDir, Times) ->
     Ebin = filename:join(AppDir, "ebin"),
     ok = add_patha(Ebin),
-    BaselineThreads = no_threads(),
+    CheckThreads = thread_count_check_supported(),
+    BaselineThreads =
+        case CheckThreads of
+            true -> no_threads();
+            false -> unsupported
+        end,
     io:format("same-version reload baseline threads: ~p~n", [BaselineThreads]),
     lists:foreach(
         fun(I) ->
             ok = slave_load_delete_purge_once(Ebin),
-            Threads = wait_thread_count_at_most(BaselineThreads, 2000),
-            io:format("same-version reload iteration ~p threads: ~p~n", [I, Threads]),
-            case Threads =< BaselineThreads of
-                true -> ok;
-                false -> exit({thread_count_increased, I, BaselineThreads, Threads})
-            end
+            ok = maybe_assert_same_version_thread_count(I, BaselineThreads)
         end,
         lists:seq(1, Times)
     ),
     ?assertEqual(false, erlang:check_old_code(quicer_nif)),
+    ok = maybe_assert_final_thread_count(BaselineThreads),
+    ok.
+
+maybe_assert_same_version_thread_count(_I, unsupported) ->
+    ok;
+maybe_assert_same_version_thread_count(I, BaselineThreads) ->
+    Threads = wait_thread_count_at_most(BaselineThreads, 2000),
+    io:format("same-version reload iteration ~p threads: ~p~n", [I, Threads]),
+    case Threads =< BaselineThreads of
+        true -> ok;
+        false -> exit({thread_count_increased, I, BaselineThreads, Threads})
+    end.
+
+maybe_assert_final_thread_count(unsupported) ->
+    ok;
+maybe_assert_final_thread_count(BaselineThreads) ->
     ?assertEqual(BaselineThreads, no_threads()),
     ok.
 
@@ -1396,6 +1428,7 @@ slave_assert_ping(Stream, Payload) ->
 
 -spec no_threads() -> integer().
 no_threads() ->
+    true = thread_count_check_supported(),
     StatusFile = filename:join(["/proc", os:getpid(), "status"]),
     {ok, Status} = file:read_file(StatusFile),
     [ThreadsLine] = [
@@ -1405,3 +1438,6 @@ no_threads() ->
     ],
     ["Threads:", Count] = string:tokens(ThreadsLine, "\t "),
     list_to_integer(Count).
+
+thread_count_check_supported() ->
+    os:type() =:= {unix, linux}.

--- a/test/quicer_upgrade_SUITE.erl
+++ b/test/quicer_upgrade_SUITE.erl
@@ -131,13 +131,18 @@ groups() ->
     [
         {old_to_current, [sequence], [
             tc_upgrade_basic_nif_reload,
+            tc_application_upgrade_with_conn,
+            tc_application_upgrade_with_listener,
             tc_upgrade_soft_and_hard_purge,
             tc_application_upgrade,
             tc_upgrade_with_traffic,
             tc_unload_module_with_bg_traffic
         ]},
         {release, [sequence], [
-            tc_release_package_contract,
+            tc_release_package_contract
+        ]},
+        {same_version_upgrade, [sequence], [
+            tc_same_version_upgrade_basic_nif_reload,
             tc_same_version_load_delete_purge_no_thread_growth
         ]}
     ].
@@ -157,12 +162,15 @@ all() ->
                 tc_upgrade_basic_nif_reload,
                 tc_upgrade_soft_and_hard_purge,
                 tc_application_upgrade,
+                tc_application_upgrade_with_conn,
+                tc_application_upgrade_with_listener,
                 tc_upgrade_with_traffic,
                 tc_unload_module_with_bg_traffic,
                 tc_release_package_contract,
+                tc_same_version_upgrade_basic_nif_reload,
                 tc_same_version_load_delete_purge_no_thread_growth
             ],
-    LocalTcs ++ [{group, old_to_current}, {group, release}].
+    LocalTcs ++ [{group, old_to_current}, {group, release}, {group, same_version_upgrade}].
 
 %%--------------------------------------------------------------------
 %% @spec TestCase(Config0) ->
@@ -276,6 +284,7 @@ tc_upgrade_basic_nif_reload(Config) ->
         ?assertEqual(1, maps:get(abi_version, Info)),
         %% THEN: 'old' code exists
         true = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        assert_remote_schedulers_not_blocked(Node),
         ok
     end).
 
@@ -301,6 +310,67 @@ tc_upgrade_soft_and_hard_purge(Config) ->
         %% THEN: old code is purged.
         false = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
         assert_remote_alive(Node),
+        assert_remote_schedulers_not_blocked(Node),
+        ok
+    end).
+
+tc_application_upgrade_with_conn(Config) ->
+    with_slave(Config, fun(Node) ->
+        %% GIVEN: when slave runs old vsn app
+        {ok, OldVsn} = rpc_call(Node, ?MODULE, slave_start_old_application, []),
+        ?assertEqual(old_version(Config), OldVsn),
+
+        {ok, Conn1} = rpc_call(Node, quicer, open_connection, []),
+        {ok, Conn2} = rpc_call(Node, quicer, open_connection, []),
+        {ok, Cnts} = rpc_call(Node, quicer, perf_counters, []),
+        ?assertEqual(2, proplists:get_value(conn_active, Cnts)),
+        _ = rpc_call(Node, quicer, close_connection, [
+            Conn1, ?QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0, 1000
+        ]),
+        _ = rpc_call(Node, quicer, close_connection, [
+            Conn2, ?QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0, 1000
+        ]),
+        {ok, Cnts2} = rpc_call(Node, quicer, perf_counters, []),
+        ?assertEqual(0, proplists:get_value(conn_active, Cnts2)),
+
+        %% WHEN: upgrade app with release handler
+        {ok, UpgradeInfo} = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_application,
+            [current_app_dir(Config), old_app_dir(Config)]
+        ),
+        assert_remote_alive(Node),
+        %% THEN: app vsn is switched to new
+        ?assertEqual(current_version(Config), maps:get(vsn, UpgradeInfo)),
+        ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, UpgradeInfo)),
+        assert_remote_schedulers_not_blocked(Node),
+        ok
+    end).
+
+tc_application_upgrade_with_listener(Config) ->
+    with_slave(Config, fun(Node) ->
+        %% GIVEN: when slave runs old vsn app
+        {ok, OldVsn} = rpc_call(Node, ?MODULE, slave_start_old_application, []),
+        ?assertEqual(old_version(Config), OldVsn),
+        LConfig = quicer_test_lib:default_listen_opts(Config),
+        Port = quicer_test_lib:select_free_port(udp),
+        {ok, L} = rpc_call(Node, quicer, listen, [Port, LConfig]),
+
+        rpc_call(Node, ?MODULE, slave_stop_all_listeners, []),
+
+        %% WHEN: upgrade app with release handler
+        {ok, UpgradeInfo} = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_application,
+            [current_app_dir(Config), old_app_dir(Config)]
+        ),
+        assert_remote_alive(Node),
+        %% THEN: app vsn is switched to new
+        ?assertEqual(current_version(Config), maps:get(vsn, UpgradeInfo)),
+        ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, UpgradeInfo)),
+        assert_remote_schedulers_not_blocked(Node),
         ok
     end).
 
@@ -320,6 +390,7 @@ tc_application_upgrade(Config) ->
         %% THEN: app vsn is switched to new
         ?assertEqual(current_version(Config), maps:get(vsn, UpgradeInfo)),
         ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, UpgradeInfo)),
+        assert_remote_schedulers_not_blocked(Node),
         ok
     end).
 
@@ -350,8 +421,16 @@ tc_upgrade_with_traffic(Config) ->
         %% WHEN: we purge the code after stopped the traffic and the listener.
         ok = rpc_call(Node, ?MODULE, slave_stop_ping_pair, [Pair]),
         ct:pal("rpc slave_stop_ping_pair ok"),
+
+        timer:sleep(3000),
+
+        %%% @WHEN: conns and listeners are killed.
+        rpc_call(Node, ?MODULE, slave_stop_all_conns, []),
+        rpc_call(Node, ?MODULE, slave_stop_all_listeners, []),
+
         %% THEN: purge success and no killed process.
-        ?assertEqual(false, rpc_call(Node, code, purge, [quicer_nif])),
+        ?assertEqual(1, rpc:call(Node, quicer, get_registration_refcnt, [global], 60000)),
+        ?assertEqual(false, rpc:call(Node, code, purge, [quicer_nif], 60000)),
         %% THEN: no old code for quicer_nif
         ?assertEqual(false, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
         maybe_assert_thread_count_at_most(Node, CheckThreads, NewNoThreads),
@@ -419,6 +498,30 @@ tc_release_package_contract(Config) ->
     with_slave(Config, fun(Node) ->
         ok = rpc_call(Node, ?MODULE, slave_load_release_nif, [ReleaseAppDir]),
         assert_remote_alive(Node),
+        assert_remote_schedulers_not_blocked(Node),
+        ok
+    end).
+
+tc_same_version_upgrade_basic_nif_reload(Config) ->
+    SameAppDir = same_version_app_dir(Config),
+    ok = copy_app_dir(current_app_dir(Config), SameAppDir),
+    with_slave(Config, fun(Node) ->
+        CurrentPriv = rpc_call(Node, ?MODULE, slave_load_current_quicer, [current_app_dir(Config)]),
+        assert_remote_alive(Node),
+        ?assertEqual(current_priv_dir(Config), CurrentPriv),
+        {ok, Info} = rpc_call(
+            Node,
+            ?MODULE,
+            slave_upgrade_nif,
+            [SameAppDir, current_app_dir(Config)]
+        ),
+        assert_remote_alive(Node),
+        ?assertEqual(filename:join(SameAppDir, "priv"), maps:get(priv_dir, Info)),
+        ?assertEqual(1, maps:get(abi_version, Info)),
+        true = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        true = rpc_call(Node, code, soft_purge, [quicer_nif]),
+        false = rpc_call(Node, erlang, check_old_code, [quicer_nif]),
+        assert_remote_schedulers_not_blocked(Node),
         ok
     end).
 
@@ -428,6 +531,7 @@ tc_same_version_load_delete_purge_no_thread_growth(Config) ->
             current_app_dir(Config), 10
         ]),
         assert_remote_alive(Node),
+        assert_remote_schedulers_not_blocked(Node),
         ok
     end).
 
@@ -527,11 +631,18 @@ old_app_dir(Config) ->
 current_app_dir(Config) ->
     ?config(current_quicer_app_dir, Config).
 
+same_version_app_dir(Config) ->
+    filename:join([?config(priv_dir, Config), "same_version_upgrade", "quicer"]).
+
 old_priv_dir(Config) ->
     filename:join(old_app_dir(Config), "priv").
 
 current_priv_dir(Config) ->
     filename:join(current_app_dir(Config), "priv").
+
+copy_app_dir(From, To) ->
+    ok = ensure_clean_dir(To),
+    copy_dir_files(From, To).
 
 env_or_default(Name, Default) ->
     case os:getenv(Name) of
@@ -920,7 +1031,7 @@ rpc_call(Node, M, F, A) ->
 rpc_call(Node, M, F, A, Timeout) ->
     case rpc:call(Node, M, F, A, Timeout) of
         {badrpc, Reason} ->
-            ct:fail({rpc_failed, Node, M, F, A, Reason});
+            ct:fail("~p", [{rpc_failed, Node, M, F, A, Reason}]);
         Result ->
             Result
     end.
@@ -928,6 +1039,10 @@ rpc_call(Node, M, F, A, Timeout) ->
 assert_remote_alive(Node) ->
     pong = net_adm:ping(Node),
     true = rpc_call(Node, erlang, is_alive, []),
+    ok.
+
+assert_remote_schedulers_not_blocked(Node) ->
+    ok = rpc_call(Node, ?MODULE, assert_schedulers_not_blocked, []),
     ok.
 
 maybe_no_threads(Node, true) ->
@@ -953,6 +1068,17 @@ slave_load_old_quicer() ->
     {ok, _} = application:ensure_all_started(quicer),
     OldEbin = code:lib_dir(quicer, ebin),
     ok = assert_module_loaded_from(quicer_nif, OldEbin),
+    code:priv_dir(quicer).
+
+slave_load_current_quicer(CurrentAppDir) ->
+    slave_purge_quicer_modules(),
+    CurrentEbin = filename:join(CurrentAppDir, "ebin"),
+    CurrentPriv = filename:join(CurrentAppDir, "priv"),
+    ok = add_patha(CurrentEbin),
+    ok = ensure_quicer_loaded(),
+    {ok, _} = application:ensure_all_started(quicer),
+    ok = assert_module_loaded_from(quicer_nif, CurrentEbin),
+    CurrentPriv = code:priv_dir(quicer),
     code:priv_dir(quicer).
 
 slave_load_release_nif(ReleaseAppDir) ->
@@ -1066,14 +1192,18 @@ slave_start_old_application() ->
     {ok, Vsn}.
 
 slave_upgrade_application(CurrentAppDir, OldAppDir) ->
+    io:format("upgrade_app start ~p", [OldAppDir]),
     CurrentEbin = filename:join(CurrentAppDir, "ebin"),
     OldEbin = filename:join(OldAppDir, "ebin"),
     case release_handler:upgrade_app(quicer, CurrentAppDir) of
-        {ok, _Unpurged} ->
+        {ok, Unpurged} ->
+            io:format("upgrade_app success ~p", [Unpurged]),
             ok;
         {error, {old_processes, _} = Reason} ->
+            io:format("upgrade_app failed ~p", [Reason]),
             exit(Reason);
         {error, Reason} ->
+            io:format("upgrade_app failed ~p", [Reason]),
             exit({upgrade_app_failed, Reason})
     end,
     ok = add_patha(CurrentEbin),
@@ -1323,17 +1453,20 @@ slave_ping_pair_loop(Server, Conn, Stream) ->
             slave_ping_pair_loop(Server, Conn, Stream);
         {stop, From, Ref} ->
             From ! {Ref, ok},
-            slave_ping_pair_stopped();
+            slave_ping_pair_stopped(Server);
         {'EXIT', Server, Reason} ->
             slave_ping_pair_loop({exited, Server, Reason}, Conn, Stream);
         {'EXIT', _Pid, _Reason} ->
             slave_ping_pair_loop(Server, Conn, Stream)
     end.
 
-slave_ping_pair_stopped() ->
+%% Park,  to keep slave node alive.
+slave_ping_pair_stopped(Server) ->
+    io:format("is client running old code: ~p", [erlang:check_process_code(self(), quicer_nif)]),
+    io:format("is server running old code: ~p", [erlang:check_process_code(Server, quicer_nif)]),
     receive
         _Any ->
-            slave_ping_pair_stopped()
+            slave_ping_pair_stopped(Server)
     end.
 
 slave_start_ping_server(Config, Port) ->
@@ -1410,8 +1543,13 @@ slave_ping_server_loop(Listener, Conn, Stream) ->
         stop ->
             io:format("server loop stop"),
             _ = quicer:close_connection(Conn),
+            %            _ = quicer:stop_listener(Listener),
             _ = quicer:close_listener(Listener),
-            ok
+            io:format("server listener stopped"),
+            %% long parking
+            receive
+                unblock -> ok
+            end
     end.
 
 slave_assert_ping(Stream, Payload) ->
@@ -1425,6 +1563,23 @@ slave_assert_ping(Stream, Payload) ->
         Error ->
             {error, {send_failed, Error}}
     end.
+
+slave_stop_all_listeners() ->
+    lists:foreach(
+        fun(L) ->
+            _ = quicer:stop_listener(L),
+            _ = quicer:close_listener(L)
+        end,
+        quicer:get_listeners(global)
+    ).
+
+slave_stop_all_conns() ->
+    lists:foreach(
+        fun(C) ->
+            _ = quicer:close_connection(C, ?QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0, 1000)
+        end,
+        quicer:get_connections(global)
+    ).
 
 -spec no_threads() -> integer().
 no_threads() ->
@@ -1441,3 +1596,38 @@ no_threads() ->
 
 thread_count_check_supported() ->
     os:type() =:= {unix, linux}.
+
+assert_schedulers_not_blocked() ->
+    Parent = self(),
+    Workers = [
+        begin
+            {Pid, MonitorRef} = spawn_opt(
+                fun() ->
+                    Parent ! {scheduler_probe, self(), Scheduler, erlang:system_info(scheduler_id)}
+                end,
+                [monitor, {scheduler, Scheduler}]
+            ),
+            {Scheduler, Pid, MonitorRef}
+        end
+     || Scheduler <- lists:seq(1, erlang:system_info(schedulers_online))
+    ],
+    lists:foreach(fun collect_scheduler_probe/1, Workers),
+    ok.
+
+collect_scheduler_probe({Scheduler, Pid, MonitorRef}) ->
+    receive
+        {scheduler_probe, Pid, Scheduler, Scheduler} ->
+            ok;
+        {scheduler_probe, Pid, Scheduler, ActualScheduler} ->
+            exit({scheduler_probe_wrong_scheduler, Scheduler, ActualScheduler})
+    after 5000 ->
+        exit({scheduler_probe_timeout, Scheduler})
+    end,
+    receive
+        {'DOWN', MonitorRef, process, Pid, normal} ->
+            ok;
+        {'DOWN', MonitorRef, process, Pid, Reason} ->
+            exit({scheduler_probe_exit, Scheduler, Reason})
+    after 5000 ->
+        exit({scheduler_probe_down_timeout, Scheduler})
+    end.

--- a/test/quicer_upgrade_SUITE.erl
+++ b/test/quicer_upgrade_SUITE.erl
@@ -94,6 +94,19 @@ end_per_group(_GroupName, _Config) ->
 %% Reason = term()
 %% @end
 %%--------------------------------------------------------------------
+init_per_testcase(Name, Config) when
+    Name =:= tc_unload_module_with_bg_traffic orelse
+        Name =:= tc_upgrade_with_traffic orelse
+        Name =:= tc_application_upgrade_on_ct_node
+->
+    Current = lists:sublist(string:tokens(current_version(Config), "."), 2),
+    case lists:sublist(string:tokens(old_version(), "."), 2) of
+        Current ->
+            Config;
+        _ ->
+            %% skip if mismatch current major, minor
+            {skip, "unsupported_upgrade_path "}
+    end;
 init_per_testcase(TestCase, Config) ->
     case erlang:function_exported(?MODULE, TestCase, 2) of
         false ->
@@ -131,9 +144,11 @@ groups() ->
     [
         {old_to_current, [sequence], [
             tc_upgrade_basic_nif_reload,
+            tc_code_upgrade_on_ct_node,
             tc_application_upgrade_with_conn,
             tc_application_upgrade_with_listener,
             tc_upgrade_soft_and_hard_purge,
+            tc_application_upgrade_on_ct_node,
             tc_application_upgrade,
             tc_upgrade_with_traffic,
             tc_unload_module_with_bg_traffic
@@ -160,8 +175,10 @@ all() ->
         quicer_test_lib:all_tcs(?MODULE) --
             [
                 tc_upgrade_basic_nif_reload,
+                tc_code_upgrade_on_ct_node,
                 tc_upgrade_soft_and_hard_purge,
                 tc_application_upgrade,
+                tc_application_upgrade_on_ct_node,
                 tc_application_upgrade_with_conn,
                 tc_application_upgrade_with_listener,
                 tc_upgrade_with_traffic,
@@ -288,6 +305,43 @@ tc_upgrade_basic_nif_reload(Config) ->
         ok
     end).
 
+tc_code_upgrade_on_ct_node(Config) ->
+    try
+        %% GIVEN: CT node runs old vsn quicer
+        {ok, OldVsn} = local_start_old_application(Config),
+        ?assertEqual(old_version(Config), OldVsn),
+        ?assertEqual(old_priv_dir(Config), code:priv_dir(quicer)),
+        {ok, Conn} = quicer:open_connection(),
+        %% note, reg refcnt is bumped.
+        ?assertEqual(2, quicer:get_registration_refcnt(global)),
+        %_ = quicer:close_connection(Conn),
+        ?assertEqual(false, erlang:check_old_code(quicer_nif)),
+        %% WHEN we close the old conn with old code
+        _ = quicer:close_connection(Conn),
+        %% WHEN: CT node loads current quicer_nif from a different app dir
+        {ok, Info} = local_upgrade_nif(Config),
+        %% THEN: quicer_nif is loaded from current code and old code is visible
+        ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, Info)),
+        ?assertEqual(1, maps:get(abi_version, Info)),
+        ?assertEqual(true, erlang:check_old_code(quicer_nif)),
+        ok = assert_schedulers_not_blocked(),
+        %% note, reg refcnt starts from 1 due to the new code loaded, new VMA.
+        ?assertEqual(1, quicer:get_registration_refcnt(global)),
+        ?assertEqual(1, quicer:get_registration_refcnt(global)),
+        {ok, Conn2} = quicer:open_connection(),
+        %% WHEN we close the new conn with new code
+        _ = quicer:close_connection(Conn2),
+        %% WHEN: old code is soft-purged
+        ?assertEqual(true, code:soft_purge(quicer_nif)),
+        %% WHEN: old code is purged
+        ?assertEqual(false, code:purge(quicer_nif)),
+        %% THEN: no old quicer_nif code remains
+        false = erlang:check_old_code(quicer_nif),
+        ok
+    after
+        local_cleanup_quicer(Config)
+    end.
+
 tc_upgrade_soft_and_hard_purge(Config) ->
     with_slave(Config, fun(Node) ->
         _ = rpc_call(Node, ?MODULE, slave_load_old_quicer, []),
@@ -355,7 +409,7 @@ tc_application_upgrade_with_listener(Config) ->
         ?assertEqual(old_version(Config), OldVsn),
         LConfig = quicer_test_lib:default_listen_opts(Config),
         Port = quicer_test_lib:select_free_port(udp),
-        {ok, L} = rpc_call(Node, quicer, listen, [Port, LConfig]),
+        {ok, _L} = rpc_call(Node, quicer, listen, [Port, LConfig]),
 
         rpc_call(Node, ?MODULE, slave_stop_all_listeners, []),
 
@@ -373,6 +427,23 @@ tc_application_upgrade_with_listener(Config) ->
         assert_remote_schedulers_not_blocked(Node),
         ok
     end).
+
+tc_application_upgrade_on_ct_node(Config) ->
+    try
+        %% GIVEN: CT node runs old vsn app from the prepared old dir
+        {ok, OldVsn} = local_start_old_application(Config),
+        ?assertEqual(old_version(Config), OldVsn),
+        %% WHEN: CT node upgrades app with release_handler
+        {ok, UpgradeInfo} = local_upgrade_application(Config),
+        %% THEN: app vsn is switched to new on the CT node
+        ?assertEqual(current_version(Config), maps:get(vsn, UpgradeInfo)),
+        ?assertEqual(current_priv_dir(Config), maps:get(priv_dir, UpgradeInfo)),
+        ok = assert_schedulers_not_blocked(),
+        ?assertEqual(false, erlang:check_old_code(quicer_nif)),
+        ok
+    after
+        local_cleanup_quicer(Config)
+    end.
 
 tc_application_upgrade(Config) ->
     with_slave(Config, fun(Node) ->
@@ -411,25 +482,16 @@ tc_upgrade_with_traffic(Config) ->
             [current_app_dir(Config), old_app_dir(Config), 5000]
         ),
         ct:pal("upgrade-with-traffic NIF reload result: ~p", [UpgradeResult]),
-        timer:sleep(1000),
         NewNoThreads = maybe_no_threads(Node, CheckThreads),
-
         assert_remote_alive(Node),
         %% THEN: old code is still in use and new code spawn more worker treads
         ?assertEqual(true, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
         maybe_assert_thread_growth(OldNoThreads, NewNoThreads),
         %% WHEN: we purge the code after stopped the traffic and the listener.
         ok = rpc_call(Node, ?MODULE, slave_stop_ping_pair, [Pair]),
+        ?assertEqual(1, rpc_call(Node, quicer, get_registration_refcnt, [global])),
         ct:pal("rpc slave_stop_ping_pair ok"),
-
-        timer:sleep(3000),
-
-        %%% @WHEN: conns and listeners are killed.
-        rpc_call(Node, ?MODULE, slave_stop_all_conns, []),
-        rpc_call(Node, ?MODULE, slave_stop_all_listeners, []),
-
         %% THEN: purge success and no killed process.
-        ?assertEqual(1, rpc:call(Node, quicer, get_registration_refcnt, [global], 60000)),
         ?assertEqual(false, rpc:call(Node, code, purge, [quicer_nif], 60000)),
         %% THEN: no old code for quicer_nif
         ?assertEqual(false, rpc_call(Node, erlang, check_old_code, [quicer_nif])),
@@ -643,6 +705,57 @@ current_priv_dir(Config) ->
 copy_app_dir(From, To) ->
     ok = ensure_clean_dir(To),
     copy_dir_files(From, To).
+
+local_start_old_application(Config) ->
+    slave_purge_quicer_modules(),
+    OldEbin = filename:join(old_app_dir(Config), "ebin"),
+    ok = add_patha(OldEbin),
+    ok = ensure_quicer_loaded(),
+    {ok, _} = application:ensure_all_started(quicer),
+    ok = assert_module_loaded_from(quicer_nif, OldEbin),
+    {ok, Vsn} = application:get_key(quicer, vsn),
+    {ok, Vsn}.
+
+local_upgrade_nif(Config) ->
+    CurrentEbin = filename:join(current_app_dir(Config), "ebin"),
+    ok = add_patha(CurrentEbin),
+    case code:load_file(quicer_nif) of
+        {module, quicer_nif} -> ok;
+        {error, not_purged} -> ok
+    end,
+    ok = assert_module_loaded_from(quicer_nif, CurrentEbin),
+    {ok, #{
+        priv_dir => code:priv_dir(quicer),
+        abi_version => quicer:abi_version(),
+        loaded => code:is_loaded(quicer_nif)
+    }}.
+
+local_upgrade_application(Config) ->
+    CurrentAppDir = current_app_dir(Config),
+    OldAppDir = old_app_dir(Config),
+    CurrentEbin = filename:join(CurrentAppDir, "ebin"),
+    OldEbin = filename:join(OldAppDir, "ebin"),
+    case release_handler:upgrade_app(quicer, CurrentAppDir) of
+        {ok, _Unpurged} ->
+            ok;
+        {error, Reason} ->
+            ct:fail({local_upgrade_app_failed, Reason})
+    end,
+    ok = add_patha(CurrentEbin),
+    ok = assert_module_loaded_from(quicer_nif, CurrentEbin),
+    ok = assert_no_modules_loaded_from(OldEbin),
+    ok = assert_no_old_code(quicer_modules()),
+    {ok, Vsn} = application:get_key(quicer, vsn),
+    {ok, #{
+        vsn => Vsn,
+        priv_dir => code:priv_dir(quicer),
+        loaded => code:is_loaded(quicer_nif)
+    }}.
+
+local_cleanup_quicer(Config) ->
+    _ = catch slave_purge_quicer_modules(),
+    _ = code:add_patha(filename:join(current_app_dir(Config), "ebin")),
+    ok.
 
 env_or_default(Name, Default) ->
     case os:getenv(Name) of
@@ -1062,6 +1175,9 @@ maybe_assert_thread_count_at_most(Node, true, MaxThreads) ->
 
 %% Functions executed on the slave node.
 
+slave_sticky_quicer() ->
+    code:stick_dir(code:lib_dir(quicer) ++ "/ebin/").
+
 slave_load_old_quicer() ->
     slave_purge_quicer_modules(),
     ok = ensure_quicer_loaded(),
@@ -1420,54 +1536,77 @@ slave_stop_ping_pair(Pid) ->
             io:format("traffic pair stop reply ~p from ~p~n", [Result, Pid]),
             erlang:demonitor(Ref, [flush]),
             Result;
-        {'DOWN', Ref, process, Pid, _Reason} ->
-            io:format("traffic pair went down before stop reply ~p~n", [Pid]),
+        {'DOWN', Ref, process, Pid, Reason} ->
+            io:format("traffic pair went down before stop reply ~p reason=~p~n", [Pid, Reason]),
+            %exit({traffic_pair_down_before_stop_reply, Reason})
             ok
     after 30000 ->
         io:format("traffic pair stop timeout ~p~n", [Pid]),
         erlang:demonitor(Ref, [flush]),
         exit(Pid, kill),
-        ok
+        exit({traffic_pair_stop_timeout, Pid})
     end.
 
 slave_ping_pair_controller(Parent, Config, Port) ->
     process_flag(trap_exit, true),
     ListenOn = "127.0.0.1:" ++ integer_to_list(Port),
     try
+        slave_stop_trace(Config, controller_start, #{port => Port}),
         {ok, Listener} = quicer:listen(ListenOn, default_listen_opts(Config)),
         Server = spawn_link(fun() -> slave_ping_server_acceptor(Listener) end),
         {ok, Conn} = quicer:connect("127.0.0.1", Port, default_conn_opts(), 5000),
         {ok, Stream} = quicer:start_stream(Conn, [{active, true}]),
         ok = slave_assert_ping(Stream, <<"before-upgrade">>),
         Parent ! {self(), ready},
-        slave_ping_pair_loop(Server, Conn, Stream)
+        slave_ping_pair_loop(Config, Server, Conn, Stream)
     catch
         Class:Reason:Stacktrace ->
+            slave_stop_trace(Config, controller_failed, {Class, Reason, Stacktrace}),
             Parent ! {self(), failed, {Class, Reason, Stacktrace}}
     end.
 
-slave_ping_pair_loop(Server, Conn, Stream) ->
+slave_ping_pair_loop(Config, Server, Conn, Stream) ->
     receive
         {ping, From, Ref, Payload} ->
             From ! {Ref, slave_assert_ping(Stream, Payload)},
-            slave_ping_pair_loop(Server, Conn, Stream);
+            slave_ping_pair_loop(Config, Server, Conn, Stream);
         {stop, From, Ref} ->
-            From ! {Ref, ok},
-            slave_ping_pair_stopped(Server);
+            From ! {Ref, slave_ping_pair_stopped(Config, Server, Conn, Stream)};
         {'EXIT', Server, Reason} ->
-            slave_ping_pair_loop({exited, Server, Reason}, Conn, Stream);
+            slave_ping_pair_loop(Config, {exited, Server, Reason}, Conn, Stream);
         {'EXIT', _Pid, _Reason} ->
-            slave_ping_pair_loop(Server, Conn, Stream)
+            slave_ping_pair_loop(Config, Server, Conn, Stream)
     end.
 
 %% Park,  to keep slave node alive.
-slave_ping_pair_stopped(Server) ->
-    io:format("is client running old code: ~p", [erlang:check_process_code(self(), quicer_nif)]),
-    io:format("is server running old code: ~p", [erlang:check_process_code(Server, quicer_nif)]),
-    receive
-        _Any ->
-            slave_ping_pair_stopped(Server)
-    end.
+slave_ping_pair_stopped(Config, Server, Conn, Stream) ->
+    ClientOldCode = erlang:check_process_code(self(), quicer_nif),
+    ServerOldCode = server_running_old_code(Server),
+    slave_stop_trace(Config, stop_enter, #{
+        client_old_code => ClientOldCode, server_old_code => ServerOldCode
+    }),
+    io:format("is client running old code: ~p", [ClientOldCode]),
+    io:format("is server running old code: ~p", [ServerOldCode]),
+    slave_stop_ping_pair_resources(Config, Server, Conn, Stream),
+    slave_stop_trace(Config, before_gc, ok),
+    erlang:garbage_collect(),
+    slave_stop_trace(Config, after_gc, ok),
+    ok.
+%% receive
+%%     _Any ->
+%%         slave_ping_pair_stopped(Server)
+%% end.
+
+server_running_old_code({exited, _Server, _Reason}) ->
+    false;
+server_running_old_code(Server) when is_pid(Server) ->
+    erlang:check_process_code(Server, quicer_nif).
+
+slave_stop_trace(Config, Step, Data) ->
+    Line = io_lib:format("~p ~p~n", [Step, Data]),
+    File = filename:join(?config(priv_dir, Config), "peer_stop_trace.log"),
+    _ = catch file:write_file(File, Line, [append]),
+    ok.
 
 slave_start_ping_server(Config, Port) ->
     Parent = self(),
@@ -1517,12 +1656,32 @@ slave_ping_server(Parent, Config, Port) ->
             Parent ! {self(), failed, Reason}
     end.
 
-slave_stop_ping_pair_resources(Server, Conn, Stream) ->
-    _ = catch quicer:close_stream(Stream),
-    _ = catch quicer:close_connection(Conn),
-    catch exit(Server, shutdown),
-    timer:sleep(3000),
+slave_stop_ping_pair_resources(Config, Server, Conn, Stream) ->
+    slave_stop_trace(Config, before_close_stream, Stream),
+    CloseStream = catch quicer:close_stream(Stream, 1000),
+    slave_stop_trace(Config, after_close_stream, CloseStream),
+    slave_stop_trace(Config, before_close_connection, Conn),
+    CloseConn = catch quicer:close_connection(Conn, ?QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0, 1000),
+    slave_stop_trace(Config, after_close_connection, CloseConn),
+    ok = slave_stop_ping_server(Config, Server),
     ok.
+
+slave_stop_ping_server(Config, {exited, Server, Reason}) ->
+    slave_stop_trace(Config, server_already_exited, {Server, Reason}),
+    ok;
+slave_stop_ping_server(Config, Server) when is_pid(Server) ->
+    Ref = erlang:monitor(process, Server),
+    slave_stop_trace(Config, before_server_stop, Server),
+    Server ! stop,
+    receive
+        {'DOWN', Ref, process, Server, Reason} ->
+            slave_stop_trace(Config, after_server_stop, Reason),
+            ok
+    after 5000 ->
+        erlang:demonitor(Ref, [flush]),
+        slave_stop_trace(Config, server_stop_timeout, Server),
+        exit({ping_server_stop_timeout, Server})
+    end.
 
 slave_ping_server_loop(Listener, Conn, Stream) ->
     receive
@@ -1546,10 +1705,7 @@ slave_ping_server_loop(Listener, Conn, Stream) ->
             %            _ = quicer:stop_listener(Listener),
             _ = quicer:close_listener(Listener),
             io:format("server listener stopped"),
-            %% long parking
-            receive
-                unblock -> ok
-            end
+            ok
     end.
 
 slave_assert_ping(Stream, Payload) ->
@@ -1570,7 +1726,7 @@ slave_stop_all_listeners() ->
             _ = quicer:stop_listener(L),
             _ = quicer:close_listener(L)
         end,
-        quicer:get_listeners(global)
+        quicer:get_listeners()
     ).
 
 slave_stop_all_conns() ->


### PR DESCRIPTION
- add hot upgrades tests from old 0.2.5
- clarify hot upgrade only support from patched version due to msquic
    hot upgrade without any listener, conns are fine but still not suggested.
- ci pipeline maintenance 

caught new issue: #421 #422