### PR TITLE
build: demote gcc maybe-uninitialized to warning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,11 +74,11 @@ jobs:
       matrix:
         erlang:
           - otp: 26.2.5.14-1
-            builder: 5.6-2:1.15.7-26.2.5.14-1
-          - otp: 27.3.4.2-3
-            builder: 5.6-2:1.18.3-27.3.4.2-3
-          - otp: 28.2-2
-            builder: 6.0-9:1.19.1-28.2-2
+            builder: 6.1-8:1.15.7-26.2.5.14-1
+          - otp: 27.3.4.2-8
+            builder: 6.1-8:1.18.3-27.3.4.2-8
+          - otp: 28.4.1-4
+            builder: 6.1-8:1.19.1-28.4.1-4
 
         openssl:
           - quictls
@@ -94,6 +94,7 @@ jobs:
           - debian11
           - amzn2023
           - amzn2
+          - el10
           - el9
           - el8
           - el7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Ap
     endif()
 endif()
 
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    # GCC 14.3 (el10) reports a 'maybe-uninitialized' false positive in
+    # msquic src/core/packet.h (QuicPktNumEncode) which builds with -Werror;
+    # demote this one diagnostic back to a warning
+    add_compile_options(-Wno-error=maybe-uninitialized)
+endif()
+
 # for lttng, quicer_tp.h
 include_directories(c_src)
 # for templ files


### PR DESCRIPTION
Port of #430 (see it for full context) to `main`.

GCC 14.3.1 (el10 / RHEL 10 toolchain) reports a `maybe-uninitialized` false positive in msquic's `src/core/packet.h` (`QuicPktNumEncode`), fatal under msquic's hardcoded `-Werror` when building from source. Add `-Wno-error=maybe-uninitialized` for GCC only (clang has no such warning group), keeping the diagnostic visible as a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyC5e51AUx2xww3LgDkHXK