### PR TITLE
Fix missing entries in statistics_v2 proplist

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -572,7 +572,7 @@ encode_parm_to_eterm(ErlNifEnv *env,
       QUIC_STATISTICS_V2 *statics = (QUIC_STATISTICS_V2 *)Buffer;
       ERL_NIF_TERM term = enif_make_list(
           env,
-          36,
+          39,
           STAT_TUPLE_U64(ATOM_QUIC_CORRELATION_ID, CorrelationId),
           STAT_TUPLE_U32(ATOM_QUIC_VERSION_NEGOTIATION, VersionNegotiation),
           STAT_TUPLE_U32(ATOM_QUIC_STATELESS_RETRY, StatelessRetry),

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -1227,7 +1227,10 @@ tc_getopt_statistics_v2(Config) ->
             {recv_total_stream_bytes, _},
             {recv_decryption_failures, _},
             {recv_valid_ack_frames, _},
-            {key_update_count, _}
+            {key_update_count, _},
+            {send_congestion_window, _},
+            {dest_cid_update_count, _},
+            {send_ecn_congestion_count, _}
         ],
         Stats
     ),


### PR DESCRIPTION
`enif_make_list()` element count (36) was smaller than the 39 tuples passed, silently dropping `send_congestion_window`, `dest_cid_update_count`, and `send_ecn_congestion_count` from the resulting proplist.