### PR TITLE
fix: clear is_recv_pending after passive->active re-arm completes the pending recv

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -1450,6 +1450,12 @@ set_stream_opt(ErlNifEnv *env,
               // Complete the pending recv (consuming 0 bytes) so the data is
               // re-indicated now that receives are re-enabled.
               MsQuic->StreamReceiveComplete(s_ctx->Stream, 0);
+              // The pending recv is completed; without this reset every later
+              // passive->active transition on the stream would issue a
+              // StreamReceiveComplete with no receive outstanding, which
+              // corrupts msquic's receive accounting and can permanently
+              // silence the stream.
+              s_ctx->is_recv_pending = FALSE;
             }
         }
       if (!set_owner_recv_mode(s_ctx->owner, env, optval))


### PR DESCRIPTION
### The bug

`set_stream_opt` handles the passive->active transition by re-enabling receives and, when `is_recv_pending` is set, calling `StreamReceiveComplete(0)` so held data is re-indicated. But `is_recv_pending` is never cleared afterwards. Once a stream has answered a single receive with `QUIC_STATUS_PENDING` in passive mode (no `recv()` caller waiting), the flag stays true forever, and every later passive->active transition on that stream calls `StreamReceiveComplete` with no receive outstanding.

With msquic 2.4+ multiple-receive completion accounting, a spurious zero-byte completion can permanently stop the stream from indicating receives: the stream stays open and healthy-looking, `setopt(active, N)` keeps returning ok, and received data is never delivered again.

### How it is hit in `{active, N}` usage

Two routine ways a receive lands in passive mode with nobody in `recv()`:

1. The disable at `{active, N}` count exhaustion is asynchronous (`StreamReceiveSetEnabled(FALSE)` from the callback), so a receive can slip in after the passive edge.
2. The stream's first data can arrive before the owner's initial `{active, N}` setopt.

Either arms `is_recv_pending`; the next re-arm correctly re-indicates the data, but from then on every `{active, N}` exhaustion/re-arm cycle fires a spurious completion. In our capture the stream died on the second spurious `StreamReceiveComplete(0)`.

### Evidence

Instrumented capture from a CI system running a credit ping-pong over one stream (fprintf tracing in the NIF receive path):

```
RECV   stream=X mode=passive len=548  pending=0   <- first data beats the initial {active,N}
LATE-RECV-PENDING stream=X len=548               <- QUIC_STATUS_PENDING, flag armed
REARM  stream=X pending=1                        <- initial {active,20}
REARM-COMPLETE0 stream=X                         <- correct: data re-indicated, delivered
RECV   stream=X mode=active ... pending=1        <- flag never cleared, all steady state
...
EDGE-DISABLE stream=X pending=1                  <- {active,N} exhaustion, flag STALE
REARM  stream=X pending=1
REARM-COMPLETE0 stream=X                         <- SPURIOUS #1 (stream survives)
... 18 more delivered messages ...
EDGE-DISABLE stream=X pending=1
REARM  stream=X pending=1
REARM-COMPLETE0 stream=X                         <- SPURIOUS #2
(no receive event ever indicated again; peer wedged with 45 messages queued)
```

Per-stream ledger: 1 `LATE-RECV-PENDING` vs 3 `REARM-COMPLETE0`.

Reproduction rate without the fix in our CI: ~1 in 15-25 runs of a site-restart test that cycles many `{active, N}` streams. With the fix, in the same test: `LATE-RECV-PENDING` count == `REARM-COMPLETE0` count exactly (175 == 175 in one full run, vs 154 vs 199 unfixed), and the outcome-level differential shows 0 stalls in 80 runs. The arming race itself is common (175 occurrences in a single passing run) - only the subsequent corruption was rare, which is why the stall was so intermittent.

### The fix

Clear `is_recv_pending` once the pending recv has been completed in the passive->active path of `set_stream_opt`. One line plus comment.

Related: fbcfe0a ("adapt to msquic 2.4 new recv mode") introduced this handling; the leak is in that path. 2cd5e59's handoff buffering is unaffected.
