### PR TITLE
feat(build): add QUICER_TLS_VER=auto and publish sys prebuilts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,8 +80,13 @@ jobs:
           - otp: 28.4.1-4
             builder: 6.1-8:1.19.1-28.4.1-4
 
+        ## quictls: bundled, builds everywhere.
+        ## sys: links the distro libcrypto, so the NIF picks up the distro's
+        ## security updates. msquic requires OpenSSL >= 3.0 for it, so the
+        ## distros below that are excluded rather than built.
         openssl:
           - quictls
+          - sys
         arch:
           - amd64
           - arm64
@@ -98,6 +103,19 @@ jobs:
           - el9
           - el8
           - el7
+        exclude:
+          ## OpenSSL 1.1.1
+          - openssl: sys
+            os: ubuntu20.04
+          - openssl: sys
+            os: debian11
+          - openssl: sys
+            os: el8
+          ## OpenSSL 1.0.2
+          - openssl: sys
+            os: amzn2
+          - openssl: sys
+            os: el7
 
     runs-on: ubuntu-22.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,34 @@ else()
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
+## QUICER_TLS_VER selects where libcrypto comes from:
+##   sys     : link the libcrypto provided by the system (needs OpenSSL >= 3.0)
+##   quictls : build and link the bundled quictls submodule
+##   auto    : sys when the system provides OpenSSL >= 3.0, quictls otherwise
+##
+## build.sh resolves 'auto' before calling cmake so that the pre-built package
+## name matches what is built. Resolve it here too, for direct cmake calls.
 if (DEFINED ENV{QUICER_TLS_VER})
-  if ($ENV{QUICER_TLS_VER} STREQUAL "sys")
+  set(QUICER_TLS_VER $ENV{QUICER_TLS_VER})
+
+  if (QUICER_TLS_VER STREQUAL "auto")
+    find_package(OpenSSL)
+    if (OPENSSL_FOUND AND NOT OPENSSL_VERSION VERSION_LESS "3.0")
+      set(QUICER_TLS_VER "sys")
+    else()
+      set(QUICER_TLS_VER "quictls")
+    endif()
+    message(STATUS "QUICER_TLS_VER=auto resolved to '${QUICER_TLS_VER}'")
+  endif()
+
+  if (QUICER_TLS_VER STREQUAL "sys")
     ## Link to sys libcrypto, auto openssl vsn
     find_package(OpenSSL REQUIRED)
     ## MsQuic 2.5+ uses 'quictls' instead of 'openssl' or 'openssl3'
     set(QUIC_TLS_LIB "quictls" CACHE STRING "QUIC_TLS_LIB")
     set(QUIC_USE_SYSTEM_LIBCRYPTO "ON")
   else()
-    set(QUIC_TLS_LIB $ENV{QUICER_TLS_VER} CACHE STRING "QUIC_TLS_LIB")
+    set(QUIC_TLS_LIB ${QUICER_TLS_VER} CACHE STRING "QUIC_TLS_LIB")
   endif()
 
 endif()

--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ firefox doc/index.html
 make ci
 ```
 
+## Selecting the TLS backend
+
+`QUICER_TLS_VER` selects where libcrypto comes from:
+
+| Value | Behaviour |
+| --- | --- |
+| `quictls` | Build and link the bundled quictls submodule. Works on any supported system. |
+| `sys` | Link the libcrypto provided by the system. Requires OpenSSL 3.0 or newer; the build fails on older systems. |
+| `auto` | Use `sys` when the system provides OpenSSL >= 3.0, `quictls` otherwise. |
+
+Prefer `sys` where it is available: the NIF then picks up the distribution's
+libcrypto security updates without rebuilding quicer. Use `auto` to get that
+on modern systems while still building on distributions that ship OpenSSL
+1.1.1 or older, such as Ubuntu 20.04, Debian 11, EL8, EL7 and Amazon Linux 2.
+
+``` sh
+QUICER_TLS_VER=auto make
+```
+
+The value is part of the pre-built package name, so `sys` and `quictls`
+artifacts are published and cached independently.
+
 # Troubleshooting 
 
 ### Log to `stdout`

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,16 @@ set -ueo pipefail
 
 MSQUIC_VERSION="$1"
 TARGET_SO='priv/libquicer_nif.so'
+
+## Resolve 'auto' before anything reads QUICER_TLS_VER: the package name
+## carries the TLS backend, and the pre-built package is downloaded before
+## cmake runs, so both must see the same concrete value.
+if [ "${QUICER_TLS_VER:-}" = 'auto' ]; then
+    QUICER_TLS_VER="$(./tls-ver.sh)"
+    export QUICER_TLS_VER
+    echo "QUICER: QUICER_TLS_VER=auto resolved to '${QUICER_TLS_VER}'"
+fi
+
 PKGNAME="$(./pkgname.sh)"
 
 detect_macos_arch() {

--- a/pkgname.sh
+++ b/pkgname.sh
@@ -29,7 +29,15 @@ esac
 ARCH="$(uname -m)"
 VSN=${QUICER_VERSION:-"$(git describe --tags --exact-match | head -1)"}
 
+## The TLS backend is part of the package name: a NIF linked against the
+## system libcrypto is not interchangeable with one linked against the
+## bundled quictls. build.sh resolves 'auto' before calling this script;
+## resolve it here too so the script is correct when called on its own.
 OPENSSL=${QUICER_TLS_VER:-openssl}
+if [ "$OPENSSL" = 'auto' ]; then
+    OPENSSL="$(dirname "$0")/tls-ver.sh"
+    OPENSSL="$($OPENSSL)"
+fi
 
 if [ -z "$VSN" ]; then
     exit 0

--- a/tls-ver.sh
+++ b/tls-ver.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+## Resolve QUICER_TLS_VER=auto to a concrete TLS backend.
+##
+## Prints 'sys' when the build host provides OpenSSL 3.0 or newer, and
+## 'quictls' otherwise.
+##
+## Linking the system libcrypto ('sys') is preferred where it is possible:
+## the resulting NIF picks up the distribution's libcrypto security updates
+## without rebuilding quicer. msquic requires OpenSSL >= 3.0 for that and
+## fails the configure step on older systems, so those fall back to the
+## bundled quictls submodule.
+##
+## Probe the development package rather than the `openssl` CLI: msquic
+## resolves the system libcrypto through CMake's FindOpenSSL, which reads the
+## headers and libraries, and a host can carry an OpenSSL 3 CLI alongside
+## 1.1.1 development files.
+
+set -eu
+
+if command -v pkg-config >/dev/null 2>&1; then
+    if pkg-config --atleast-version=3.0 libcrypto 2>/dev/null; then
+        echo 'sys'
+        exit 0
+    fi
+    ## pkg-config knows libcrypto and it is too old: no need to probe further.
+    if pkg-config --exists libcrypto 2>/dev/null; then
+        echo 'quictls'
+        exit 0
+    fi
+fi
+
+## No pkg-config, or it does not know libcrypto. Fall back to the CLI, which
+## is a weaker signal but better than assuming.
+if command -v openssl >/dev/null 2>&1; then
+    case "$(openssl version 2>/dev/null)" in
+        'OpenSSL 3.'* | 'OpenSSL '[4-9]*)
+            echo 'sys'
+            exit 0
+            ;;
+    esac
+fi
+
+echo 'quictls'


### PR DESCRIPTION
Relates to #438.

## Why

`QUICER_TLS_VER=sys` links the system libcrypto, so the NIF picks up the distribution's libcrypto security updates without rebuilding quicer. That is the better default where it works, but msquic requires OpenSSL >= 3.0 for it and fails at configure time otherwise:

```
CMake Error at msquic/submodules/CMakeLists.txt:361 (message):
  OpenSSL 3.0 not found, found 1.1.1f
```

So `sys` cannot be used unconditionally while distributions shipping OpenSSL 1.1.1 or older are still supported.

There is a second, less visible problem. The TLS backend is part of the pre-built package name (`pkgname.sh`), but the release workflow only ever published `quictls` artifacts — `0.4.8` has 140 assets, all `quictls`, none `sys`. A consumer that sets `QUICER_TLS_VER=sys` therefore requests `libquicer-<vsn>-otp<n>-sys-<system>-<arch>.gz`, gets a 404, and falls through to `building from source` in `build.sh`. The cache miss is silent, so the cost shows up as slow builds rather than an error — and on a host below OpenSSL 3.0 the source build then fails outright.

## What

**`QUICER_TLS_VER=auto`** — resolve to `sys` when the build host provides OpenSSL >= 3.0, `quictls` otherwise.

Resolution lives in `tls-ver.sh` and runs in `build.sh` *before* `pkgname.sh` is called, because the package name has to match what is actually built and the download happens before cmake runs. `CMakeLists.txt` resolves `auto` as well, so a direct `cmake` call behaves the same.

The probe prefers `pkg-config --atleast-version=3.0 libcrypto` over the `openssl` CLI, since msquic resolves the system libcrypto through CMake's `FindOpenSSL` (headers and libraries) and a host can carry an OpenSSL 3 CLI alongside 1.1.1 development files.

**Publish both variants** from the release workflow. `sys` is excluded on the five distributions below OpenSSL 3.0 — `ubuntu20.04`, `debian11`, `el8` (1.1.1), `amzn2`, `el7` (1.0.2) — where only `quictls` can be built. The seven remaining targets get both.

Existing values are unchanged: `quictls` and `sys` behave exactly as before, and an unset `QUICER_TLS_VER` still produces the legacy `-openssl-` package name.

## Notes

- macOS stays `quictls`-only. `find_package(OpenSSL)` there resolves to whatever Homebrew has rather than a system-managed libcrypto, so a published `sys` artifact would encode the builder's brew layout rather than anything stable on the consumer's machine.
- The linux release matrix grows from 72 to 114 jobs.

## Verified

| `QUICER_TLS_VER` | resolved package token |
| --- | --- |
| unset | `-openssl-` (unchanged) |
| `quictls` | `-quictls-` |
| `sys` | `-sys-` |
| `auto` | `-quictls-` on a 1.1.1 host |

`cmake` with `QUICER_TLS_VER=auto` on the same host reports `QUICER_TLS_VER=auto resolved to 'quictls'`. Workflow YAML parsed and the resulting matrix checked against the intended include/exclude set.