### PR TITLE
Rework receive path onto msquic multiple-receive mode

### DIFF
--- a/c_src/quicer_config.c
+++ b/c_src/quicer_config.c
@@ -17,6 +17,7 @@ limitations under the License.
 #include "quicer_config.h"
 #include "quicer_internal.h"
 #include "quicer_queue.h"
+#include "quicer_stream.h"
 #include "quicer_tls.h"
 #include <msquichelper.h>
 
@@ -1282,6 +1283,11 @@ create_settings(ErlNifEnv *env,
       Settings->IsSet.PeerBidiStreamCount = TRUE;
     }
 
+  // The NIF receive path (recv chain + cumulative StreamReceiveComplete)
+  // requires msquic multi-receive mode on every stream.
+  Settings->StreamMultiReceiveEnabled = TRUE;
+  Settings->IsSet.StreamMultiReceiveEnabled = TRUE;
+
   return true;
 }
 
@@ -1432,30 +1438,14 @@ set_stream_opt(ErlNifEnv *env,
       if (ACCEPTOR_RECV_MODE_PASSIVE == s_ctx->owner->active
           && !IS_SAME_TERM(ATOM_FALSE, optval))
         {
-          // Switching from passive to active: msquic receives may have been
-          // disabled (e.g. by a partial passive recv, or when an {active, N}
-          // count was exhausted).
-          // Re-enable them unconditionally.
-          //
-          // Order matters: enable BEFORE completing the pending recv. In
-          // single recv-buffer mode, StreamReceiveSetEnabled(TRUE) will NOT
-          // queue a recv flush while a read is still pending
-          // (ReadPendingLength > 0). By enabling first and then completing
-          // recv with 0, the completion itself drives the flush
-          // (QuicStreamReceiveComplete re-flushes once ReceiveEnabled is
-          // TRUE), so delivery does not depend on the enable-time flush guard.
-          MsQuic->StreamReceiveSetEnabled(s_ctx->Stream, TRUE);
-          if (s_ctx->is_recv_pending)
+          // Switching from passive to active: deliver data still pinned in
+          // the recv chain (multi-receive mode never re-indicates it), then
+          // re-enable receives, which may have been disabled when an
+          // {active, N} count was exhausted.
+          stream_deliver_recv_chain(env, s_ctx);
+          if (s_ctx->Stream && !s_ctx->is_shutdown_complete)
             {
-              // Complete the pending recv (consuming 0 bytes) so the data is
-              // re-indicated now that receives are re-enabled.
-              MsQuic->StreamReceiveComplete(s_ctx->Stream, 0);
-              // The pending recv is completed; without this reset every later
-              // passive->active transition on the stream would issue a
-              // StreamReceiveComplete with no receive outstanding, which
-              // corrupts msquic's receive accounting and can permanently
-              // silence the stream.
-              s_ctx->is_recv_pending = FALSE;
+              MsQuic->StreamReceiveSetEnabled(s_ctx->Stream, TRUE);
             }
         }
       if (!set_owner_recv_mode(s_ctx->owner, env, optval))

--- a/c_src/quicer_ctx.c
+++ b/c_src/quicer_ctx.c
@@ -200,12 +200,10 @@ init_s_ctx()
   s_ctx->imm_env = enif_alloc_env();
   s_ctx->lock = enif_mutex_create("quicer:s_ctx");
   s_ctx->is_wait_for_data = FALSE;
-  s_ctx->Buffers[0].Buffer = NULL;
-  s_ctx->Buffers[0].Length = 0;
-  s_ctx->Buffers[1].Buffer = NULL;
-  s_ctx->Buffers[1].Length = 0;
-  s_ctx->TotalBufferLength = 0;
-  s_ctx->is_recv_pending = FALSE;
+  s_ctx->recv_head = NULL;
+  s_ctx->recv_tail = NULL;
+  s_ctx->recv_avail = 0;
+  s_ctx->is_shutdown_complete = FALSE;
   s_ctx->is_closed = TRUE; // init
   s_ctx->event_mask = 0;
   s_ctx->sig_queue = NULL;
@@ -216,9 +214,25 @@ init_s_ctx()
 void
 deinit_s_ctx(QuicerStreamCTX *s_ctx)
 {
+  stream_recv_chain_free(s_ctx);
   cleanup_owner_signals(s_ctx);
   enif_mutex_destroy(s_ctx->lock);
   enif_free_env(s_ctx->env);
+}
+
+void
+stream_recv_chain_free(QuicerStreamCTX *s_ctx)
+{
+  QuicerRecvSeg *seg = s_ctx->recv_head;
+  while (seg)
+    {
+      QuicerRecvSeg *next = seg->next;
+      CXPLAT_FREE(seg, QUICER_RECV_SEG);
+      seg = next;
+    }
+  s_ctx->recv_head = NULL;
+  s_ctx->recv_tail = NULL;
+  s_ctx->recv_avail = 0;
 }
 
 void

--- a/c_src/quicer_ctx.h
+++ b/c_src/quicer_ctx.h
@@ -148,6 +148,21 @@ typedef struct QuicerConnCTX
   void *reserved3;
 } QuicerConnCTX;
 
+// One msquic RECEIVE indication that has not been fully consumed by the
+// app (multi-receive mode). Buffer descriptors point into msquic-owned
+// receive chunks; they stay valid until StreamReceiveComplete covers them
+// or the stream handle is closed.
+typedef struct QuicerRecvSeg
+{
+  struct QuicerRecvSeg *next;
+  uint64_t abs_offset;   // stream offset of this segment's first byte
+  uint64_t offset;       // bytes of this segment already consumed
+  uint64_t total;        // total bytes in this segment
+  uint32_t flags;        // QUIC_RECEIVE_FLAGS of the indication
+  uint32_t buffer_count; // entries in buffers[]
+  QUIC_BUFFER buffers[];
+} QuicerRecvSeg;
+
 typedef struct QuicerStreamCTX
 {
   uint32_t magic;
@@ -166,11 +181,15 @@ typedef struct QuicerStreamCTX
   // Set once
   ERL_NIF_TERM eHandle;
   ErlNifMutex *lock;
-  _CTX_CALLBACK_WRITE_ _CTX_NIF_READ_ QUIC_BUFFER Buffers[2];
-  _CTX_CALLBACK_WRITE_ _CTX_NIF_READ_ uint64_t TotalBufferLength;
-  _CTX_CALLBACK_WRITE_ _CTX_NIF_READ_ uint32_t BufferCount;
+  // FIFO of uncompleted RECEIVE indications, protected by lock
+  QuicerRecvSeg *recv_head;
+  QuicerRecvSeg *recv_tail;
+  uint64_t recv_avail; // unconsumed bytes across the whole chain
   _CTX_CALLBACK_READ_ BOOLEAN is_wait_for_data;
-  _CTX_CALLBACK_WRITE_ BOOLEAN is_recv_pending;
+  // SHUTDOWN_COMPLETE seen; only StreamClose may be called on the handle.
+  // (is_closed can not be used for this: it starts TRUE and stays TRUE for
+  // locally initiated streams.)
+  BOOLEAN is_shutdown_complete;
   BOOLEAN is_closed;
   // Track lifetime of Stream handle
   CXPLAT_REF_COUNT ref_count;
@@ -212,6 +231,9 @@ void destroy_config_ctx(QuicerConfigCTX *config_ctx);
 QuicerStreamCTX *init_s_ctx();
 void deinit_s_ctx(QuicerStreamCTX *s_ctx);
 void destroy_s_ctx(QuicerStreamCTX *s_ctx);
+// Free the recv chain without completing; caller must hold s_ctx->lock
+// (or be the last owner in deinit).
+void stream_recv_chain_free(QuicerStreamCTX *s_ctx);
 
 QuicerStreamSendCTX *init_send_ctx();
 void destroy_send_ctx(QuicerStreamSendCTX *send_ctx);

--- a/c_src/quicer_nif.c
+++ b/c_src/quicer_nif.c
@@ -1306,6 +1306,20 @@ openLib(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
       goto exit;
     }
 
+  {
+    // The NIF receive path requires multi-receive mode on every stream;
+    // make it the library-wide default so even connections without an
+    // applied configuration (e.g. pre-handshake) get it.
+    QUIC_SETTINGS default_settings = { 0 };
+    default_settings.StreamMultiReceiveEnabled = TRUE;
+    default_settings.IsSet.StreamMultiReceiveEnabled = TRUE;
+    status = MsQuic->SetParam(NULL,
+                              QUIC_PARAM_GLOBAL_SETTINGS,
+                              sizeof(default_settings),
+                              &default_settings);
+    assert(QUIC_SUCCEEDED(status));
+  }
+
   TP_NIF_3(success, 0, 2);
 
   res = SUCCESS(ATOM_TRUE);

--- a/c_src/quicer_queue.h
+++ b/c_src/quicer_queue.h
@@ -41,6 +41,7 @@ limitations under the License.
 #define QUICER_CERTIFICATE_PKCS12 'C0rQ' // Cr0a QUICER_CERTIFICATE_PKCS12
 #define QUICER_RESUME_TICKET 'C0rQ'      // 'Qr0c'  QUICER_RESUME_TICKET
 #define QUICER_CACERTFILE 'D0rQ'         // 'Qr0d'  QUICER_CACERTFILE
+#define QUICER_RECV_SEG 'E0rQ'           // 'Qr0e'  QUICER_RECV_SEG
 
 typedef enum ACCEPTOR_RECV_MODE
 {

--- a/c_src/quicer_stream.c
+++ b/c_src/quicer_stream.c
@@ -57,8 +57,6 @@ static QUIC_STATUS
 handle_stream_event_send_shutdown_complete(QuicerStreamCTX *s_ctx,
                                            QUIC_STREAM_EVENT *Event);
 
-static void reset_stream_recv(QuicerStreamCTX *s_ctx);
-
 static int
 signal_or_buffer(QuicerStreamCTX *s_ctx, ErlNifPid *owner, ERL_NIF_TERM sig);
 
@@ -740,13 +738,15 @@ recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     }
 
   TP_NIF_3(start, (uintptr_t)s_ctx->Stream, size_req);
-  enif_mutex_lock(s_ctx->lock);
 
-  if (!s_ctx->Stream)
+  // Hold a handle ref: chain buffers point into msquic recv chunks that
+  // are freed by StreamClose.
+  if (!LOCAL_REFCNT(get_stream_handle(s_ctx)))
     {
-      res = ERROR_TUPLE_2(ATOM_CLOSED);
-      goto Exit;
+      return ERROR_TUPLE_2(ATOM_CLOSED);
     }
+
+  enif_mutex_lock(s_ctx->lock);
 
   if (ACCEPTOR_RECV_MODE_PASSIVE != s_ctx->owner->active)
     {
@@ -754,31 +754,28 @@ recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
       goto Exit;
     }
 
-  // We have checked that the Stream is not closed/closing
-  // it is safe to use the s_ctx->Stream in following MsQuic API calls
-
-  if (s_ctx->is_recv_pending && s_ctx->TotalBufferLength > 0)
+  if (s_ctx->recv_avail > 0)
     {
-      //
-      // Buffer is ready
-      //
       uint64_t size_consumed = recvbuffer_flush(
           s_ctx,
           &bin,
-          size_req > s_ctx->TotalBufferLength ? s_ctx->TotalBufferLength
-                                              : size_req);
+          size_req > s_ctx->recv_avail ? s_ctx->recv_avail : size_req);
       TP_NIF_3(consume, (uintptr_t)s_ctx->Stream, size_consumed);
-      reset_stream_recv(s_ctx);
 
-      if (size_consumed > 0)
+      s_ctx->is_wait_for_data = FALSE;
+
+      // Cumulative completion; in multi-receive mode msquic drains
+      // size_consumed bytes from the front of the pending data.
+      if (!s_ctx->is_shutdown_complete)
         {
-          s_ctx->is_wait_for_data = FALSE;
+          MsQuic->StreamReceiveComplete(s_ctx->Stream, size_consumed);
         }
 
-      // call only when is_recv_pending is TRUE
-      MsQuic->StreamReceiveComplete(s_ctx->Stream, size_consumed);
-
       res = SUCCESS(enif_make_binary(env, &bin));
+    }
+  else if (s_ctx->is_shutdown_complete)
+    {
+      res = ERROR_TUPLE_2(ATOM_CLOSED);
     }
   else
     { // want more data in buffer
@@ -786,26 +783,14 @@ recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
       s_ctx->is_wait_for_data = TRUE;
 
       //
-      // Ensure stream recv is enabled while it is in passive mode,
-      // because we are waiting for more data.
-      //
-      // Enable BEFORE finishing any pending recv callback: in single
-      // recv-buffer mode StreamReceiveSetEnabled(TRUE) won't flush while a
-      // read is still pending, so we let the completion drive the flush
-      // instead (see the matching note in set_stream_opt). On this branch
-      // is_recv_pending is normally FALSE, so the completion is just a safety
-      // net.
+      // Receives may have been disabled (an exhausted {active, N} count
+      // calls StreamReceiveSetEnabled(FALSE)); re-enable while waiting.
       //
       if (QUIC_FAILED(status
                       = MsQuic->StreamReceiveSetEnabled(s_ctx->Stream, TRUE)))
         {
           res = ERROR_TUPLE_2(ATOM_STATUS(status));
           goto Exit;
-        }
-      // Finish the stream recv callback
-      if (s_ctx->is_recv_pending)
-        {
-          MsQuic->StreamReceiveComplete(s_ctx->Stream, 0);
         }
       // NIF caller will get {ok, not_ready}
       // this is an ack to its call
@@ -814,6 +799,7 @@ recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 
 Exit:
   enif_mutex_unlock(s_ctx->lock);
+  LOCAL_REFCNT(put_stream_handle(s_ctx));
   return res;
 }
 
@@ -857,49 +843,82 @@ shutdown_stream3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   return ret;
 }
 
+// Copy req_len bytes (all unconsumed bytes when req_len is 0) from the
+// front of the recv chain into a fresh binary, popping fully consumed
+// segments. Caller holds s_ctx->lock and must complete the returned
+// length to msquic (or be on a path where the stream is gone).
 static uint64_t
 recvbuffer_flush(QuicerStreamCTX *s_ctx, ErlNifBinary *bin, uint64_t req_len)
 {
   // note, make sure ownership of bin should be transferred, after call
-  uint64_t size = 0;
-  assert(req_len <= s_ctx->TotalBufferLength);
-
-  if (req_len == 0)
-    { // we need more data than buffer has
-      size = s_ctx->TotalBufferLength;
-    }
-  else
-    { // buffer size is larger than we want
-      size = req_len;
-    }
+  uint64_t size = (req_len == 0 || req_len > s_ctx->recv_avail)
+                      ? s_ctx->recv_avail
+                      : req_len;
 
   enif_alloc_binary(size, bin);
   assert(size == bin->size);
   assert(size > 0);
 
   unsigned char *dest = bin->data;
+  uint64_t remaining = size;
 
-  // Defense in depth: msquic guarantees TotalBufferLength == sum of buffer
-  // lengths and at most 2 buffers, but never read past the fixed Buffers[]
-  // array even if that invariant is violated.
-  for (uint32_t i = 0;
-       size > 0 && i < s_ctx->BufferCount && i < ARRAYSIZE(s_ctx->Buffers);
-       ++i)
+  while (remaining > 0)
     {
-      if (s_ctx->Buffers[i].Length <= size)
-        { // copy whole buffer
-          CxPlatCopyMemory(
-              dest, s_ctx->Buffers[i].Buffer, s_ctx->Buffers[i].Length);
-          dest += s_ctx->Buffers[i].Length;
-          size -= s_ctx->Buffers[i].Length;
+      QuicerRecvSeg *seg = s_ctx->recv_head;
+      assert(seg);
+      uint64_t skip = seg->offset;
+      for (uint32_t i = 0; remaining > 0 && i < seg->buffer_count; ++i)
+        {
+          uint64_t blen = seg->buffers[i].Length;
+          if (skip >= blen)
+            {
+              skip -= blen;
+              continue;
+            }
+          uint64_t n = blen - skip;
+          if (n > remaining)
+            {
+              n = remaining;
+            }
+          CxPlatCopyMemory(dest, seg->buffers[i].Buffer + skip, n);
+          dest += n;
+          remaining -= n;
+          seg->offset += n;
+          skip = 0;
+        }
+      if (seg->offset == seg->total)
+        {
+          s_ctx->recv_head = seg->next;
+          if (!s_ctx->recv_head)
+            {
+              s_ctx->recv_tail = NULL;
+            }
+          CXPLAT_FREE(seg, QUICER_RECV_SEG);
         }
       else
-        { // copy part of the buffer, end of copy
-          CxPlatCopyMemory(dest, s_ctx->Buffers[i].Buffer, size);
-          size = 0;
+        {
+          assert(remaining == 0);
         }
     }
-  return bin->size;
+
+  s_ctx->recv_avail -= size;
+  return size;
+}
+
+// Copy the whole event payload into a fresh binary (active mode; the
+// event buffers are only valid during the callback).
+static void
+recvbuffer_copy_event(QUIC_STREAM_EVENT *Event, ErlNifBinary *bin)
+{
+  enif_alloc_binary(Event->RECEIVE.TotalBufferLength, bin);
+  unsigned char *dest = bin->data;
+  for (uint32_t i = 0; i < Event->RECEIVE.BufferCount; ++i)
+    {
+      CxPlatCopyMemory(dest,
+                       Event->RECEIVE.Buffers[i].Buffer,
+                       Event->RECEIVE.Buffers[i].Length);
+      dest += Event->RECEIVE.Buffers[i].Length;
+    }
 }
 
 QUIC_STATUS
@@ -916,13 +935,6 @@ handle_stream_event_recv(HQUIC Stream,
   assert(Event->RECEIVE.BufferCount > 0
          || Event->RECEIVE.Flags == QUIC_RECEIVE_FLAG_FIN);
 
-  s_ctx->Buffers[0].Buffer = Event->RECEIVE.Buffers[0].Buffer;
-  s_ctx->Buffers[0].Length = Event->RECEIVE.Buffers[0].Length;
-  s_ctx->Buffers[1].Buffer = Event->RECEIVE.Buffers[1].Buffer;
-  s_ctx->Buffers[1].Length = Event->RECEIVE.Buffers[1].Length;
-  s_ctx->BufferCount = Event->RECEIVE.BufferCount;
-  s_ctx->TotalBufferLength = Event->RECEIVE.TotalBufferLength;
-
   if (Event->RECEIVE.Flags != 0)
     {
       TP_CB_3(event_recv_flag, (uintptr_t)Stream, Event->RECEIVE.Flags);
@@ -935,14 +947,44 @@ handle_stream_event_recv(HQUIC Stream,
 
   if (ACCEPTOR_RECV_MODE_PASSIVE == s_ctx->owner->active)
     { // passive receive
-      /* important:
-         for passive receive, it is not ok to call
-         MsQuic->StreamReceiveSetEnabled to enable receiving
-         because it can cause busy spinning:
-         trigger event and handle event in a loop
-      */
+      // Append to the recv chain and keep the buffers pinned (multi-receive
+      // mode: returning PENDING does not stop further indications, and
+      // StreamReceiveComplete drains cumulatively from the front).
       TP_CB_3(handle_stream_event_recv, (uintptr_t)Stream, 0);
-      s_ctx->is_recv_pending = TRUE;
+
+      uint32_t bcount = Event->RECEIVE.BufferCount;
+      QuicerRecvSeg *seg = CXPLAT_ALLOC_NONPAGED(
+          sizeof(QuicerRecvSeg) + bcount * sizeof(QUIC_BUFFER),
+          QUICER_RECV_SEG);
+      if (!seg)
+        {
+          MsQuic->StreamShutdown(Stream,
+                                 QUIC_STREAM_SHUTDOWN_FLAG_ABORT,
+                                 QUIC_STATUS_OUT_OF_MEMORY);
+          return QUIC_STATUS_SUCCESS;
+        }
+      seg->next = NULL;
+      seg->abs_offset = Event->RECEIVE.AbsoluteOffset;
+      seg->offset = 0;
+      seg->total = Event->RECEIVE.TotalBufferLength;
+      seg->flags = Event->RECEIVE.Flags;
+      seg->buffer_count = bcount;
+      for (uint32_t i = 0; i < bcount; ++i)
+        {
+          seg->buffers[i] = Event->RECEIVE.Buffers[i];
+        }
+
+      if (s_ctx->recv_tail)
+        {
+          s_ctx->recv_tail->next = seg;
+        }
+      else
+        {
+          s_ctx->recv_head = seg;
+        }
+      s_ctx->recv_tail = seg;
+      s_ctx->recv_avail += seg->total;
+
       status = QUIC_STATUS_PENDING;
 
       if (s_ctx->is_wait_for_data)
@@ -961,12 +1003,15 @@ handle_stream_event_recv(HQUIC Stream,
                                      QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL,
                                      QUIC_STATUS_UNREACHABLE);
             }
+          // one wake-up per recv call; further indications just grow the
+          // chain until the owner reads
+          s_ctx->is_wait_for_data = FALSE;
         }
     }
   else
     { // active receive
       TP_CB_3(handle_stream_event_recv, (uintptr_t)Stream, 1);
-      recvbuffer_flush(s_ctx, &bin, (uint64_t)0);
+      recvbuffer_copy_event(Event, &bin);
       BOOLEAN is_report_passive = FALSE;
       ERL_NIF_TERM eHandle = enif_make_copy(env, s_ctx->eHandle);
       ERL_NIF_TERM props_name[] = { ATOM_ABS_OFFSET, ATOM_LEN, ATOM_FLAGS };
@@ -1127,6 +1172,11 @@ handle_stream_event_shutdown_complete(QuicerStreamCTX *s_ctx,
           Event->SHUTDOWN_COMPLETE.ConnectionShutdown);
   assert(env);
 
+  // From here on only StreamClose may be called on the handle. Chain data
+  // stays readable (recv chunks live until StreamClose) but must no longer
+  // be completed to msquic.
+  s_ctx->is_shutdown_complete = TRUE;
+
   ERL_NIF_TERM props_name[] = {
     ATOM_IS_CONN_SHUTDOWN,   ATOM_IS_APP_CLOSING, ATOM_IS_SHUTDOWN_BY_APP,
     ATOM_IS_CLOSED_REMOTELY, ATOM_ERROR,          ATOM_STATUS
@@ -1231,16 +1281,53 @@ get_stream_rid1(ErlNifEnv *env, int args, const ERL_NIF_TERM argv[])
   return SUCCESS(enif_make_ulong(env, (unsigned long)s_ctx->Stream));
 }
 
-static void
-reset_stream_recv(QuicerStreamCTX *s_ctx)
+// Deliver all pinned chain data to the owner as one active-mode data
+// message, completing it to msquic. Used on passive->active transitions:
+// in multi-receive mode msquic never re-indicates data that was left
+// pending, so it must be pushed out here. Caller holds s_ctx->lock and
+// runs in a NIF call context (env is the call env).
+void
+stream_deliver_recv_chain(ErlNifEnv *env, QuicerStreamCTX *s_ctx)
 {
-  s_ctx->Buffers[0].Buffer = NULL;
-  s_ctx->Buffers[0].Length = 0;
-  s_ctx->Buffers[1].Buffer = NULL;
-  s_ctx->Buffers[1].Length = 0;
+  ErlNifBinary bin;
 
-  s_ctx->is_recv_pending = FALSE;
-  s_ctx->TotalBufferLength = 0;
+  if (s_ctx->recv_avail == 0)
+    {
+      return;
+    }
+
+  uint64_t abs_offset
+      = s_ctx->recv_head->abs_offset + s_ctx->recv_head->offset;
+  // Every segment is fully drained below, so OR-ing their indication
+  // flags (FIN, 0-RTT) is exact.
+  uint32_t flags = 0;
+  for (QuicerRecvSeg *seg = s_ctx->recv_head; seg; seg = seg->next)
+    {
+      flags |= seg->flags;
+    }
+  uint64_t len = recvbuffer_flush(s_ctx, &bin, 0);
+
+  ErlNifEnv *menv = enif_alloc_env();
+  ERL_NIF_TERM eHandle = enif_make_copy(menv, s_ctx->eHandle);
+  ERL_NIF_TERM props_name[] = { ATOM_ABS_OFFSET, ATOM_LEN, ATOM_FLAGS };
+  ERL_NIF_TERM props_value[] = { enif_make_uint64(menv, abs_offset),
+                                 enif_make_uint64(menv, len),
+                                 enif_make_int(menv, (int)flags) };
+  ERL_NIF_TERM report = make_event_with_props(menv,
+                                              enif_make_binary(menv, &bin),
+                                              eHandle,
+                                              props_name,
+                                              props_value,
+                                              3);
+  enif_send(env, &(s_ctx->owner->Pid), menv, report);
+  enif_free_env(menv);
+
+  s_ctx->is_wait_for_data = FALSE;
+
+  if (s_ctx->Stream && !s_ctx->is_shutdown_complete)
+    {
+      MsQuic->StreamReceiveComplete(s_ctx->Stream, len);
+    }
 }
 
 ERL_NIF_TERM

--- a/c_src/quicer_stream.h
+++ b/c_src/quicer_stream.h
@@ -51,6 +51,9 @@ ERL_NIF_TERM send3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM recv2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
+// Caller holds s_ctx->lock; NIF call context only.
+void stream_deliver_recv_chain(ErlNifEnv *env, struct QuicerStreamCTX *s_ctx);
+
 ERL_NIF_TERM
 shutdown_stream3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 


### PR DESCRIPTION
This replaces the single-receive `is_recv_pending` /
`StreamReceiveSetEnabled(TRUE)` + `StreamReceiveComplete(0)` re-arm
machinery with msquic's multiple-receive mode, removing the class of
receive stalls behind the recent passive-recv fixes (including the one
merged in 8c0371e).

### The bug class this removes

In single-receive mode, when `recv/2` finds no buffered data it re-arms
with `StreamReceiveSetEnabled(TRUE)` and, if an indication was pending,
`StreamReceiveComplete(0)`. msquic does not re-indicate already-buffered
data after a zero-length completion in this state, so a request/response
peer can deadlock: the data sits in msquic's recv buffer, the app waits
for a `continue` signal that never comes. We hit this in production
(request/response over passive streams); 8c0371e fixed one instance, but
the underlying re-arm dance has more corners (passive->active
transitions had a related re-indication dependency).

### What this PR does

- Enables `StreamMultiReceiveEnabled` in every `QUIC_SETTINGS` built by
  `create_settings()` and as the library-wide default at `MsQuicOpen`,
  so every stream runs in multi-receive mode. There is deliberately no
  option to run the old mode: keeping both receive state machines alive
  is how this bug class survived. (Happy to discuss making it
  configurable if you see a need.)
- Replaces the pinned single-event state (`Buffers[2]`, `BufferCount`,
  `TotalBufferLength`, `is_recv_pending`) with a FIFO chain of receive
  segments in the stream ctx. Passive indications append to the chain
  and return `QUIC_STATUS_PENDING`; `recv/2` copies from the front and
  issues one cumulative `StreamReceiveComplete` for the bytes consumed.
  The re-arm dance is gone.
- Passive->active transitions deliver the pinned chain to the owner
  directly (multi-receive mode never re-indicates pending data),
  preserving the indication flags (FIN, 0-RTT) in the delivered
  message props.
- `recv/2` takes a stream handle ref while reading: chain buffers point
  into msquic-owned recv chunks, which are freed only by `StreamClose`
  (verified against msquic 2.5.x: reset/abort paths do not free chunks,
  and `QUIC_RECV_BUF_MODE_MULTIPLE` never retires chunks).
- Adds `is_shutdown_complete` to gate recv-path msquic calls after
  `SHUTDOWN_COMPLETE`. (`is_closed` cannot serve: it stays `TRUE` for
  the whole life of locally initiated streams.)

### Behavior notes

- Active mode is unchanged (copy + implicit full completion via
  `QUIC_STATUS_SUCCESS`), but in multi-receive mode indications arrive
  per data arrival rather than per drain cycle, so `{active, N}`
  consumes N in smaller steps under load. The `passive` message
  semantics are unchanged.
- `quicer:recv/2` semantics are unchanged (returns up to Count bytes,
  `{ok, not_ready}` + `continue` signal when empty).
- Flow-control behavior is equivalent: uncompleted chain bytes occupy
  the receive window exactly as undelivered buffered data did before.

### Validation

- Full CT: quicer_SUITE 105/105, connection 82/82, listener 90/90,
  snb 34/34, reg 13/13; eunit 26/26; all 55 PropEr properties
  (including the stateful models).
- ASan+UBSan build: quicer_SUITE + snb green, plus a dedicated
  ~360-stream stress (flood + partial reads + abort/close/
  passive-active flips mid-chain): zero sanitizer findings.
- Valgrind memcheck (JIT-checked BEAM): zero definite/indirect leaks,
  no error contexts in the NIF (remaining reports are msquic
  sendmsg-cmsg and OpenSSL noise).
- Soaked at system level in our event-streaming stack (volga): full
  interop matrix vs a second QUIC implementation, plus a 51-run
  restart/failover differential against the previous quicer build.

Happy to split the settings-forcing into its own commit or add a
regression CT case for the re-arm deadlock if you'd like.

