### PR TITLE
Treat zero-length sends without FIN or START as no-ops (avoids msquic send-path wedge)

### DIFF
--- a/src/quicer.erl
+++ b/src/quicer.erl
@@ -777,19 +777,38 @@ send(Stream, Data) ->
     | {error, badarg | not_enough_mem | closed}
     | {error, stream_send_error, atom_reason()}.
 send(Stream, Data, Flag) when is_integer(Flag) ->
-    %% This is an sync send, set flag ?QUICER_SEND_FLAG_SYNC
-    case quicer_nif:send(Stream, Data, Flag bor ?QUICER_SEND_FLAG_SYNC) of
-        %% @todo make ref
-        {ok, _Len} = OK ->
-            receive
-                {quic, send_complete, Stream, false} ->
-                    OK;
-                {quic, send_complete, Stream, true} ->
-                    {error, cancelled}
-            end;
-        E ->
-            E
+    case is_zero_len_send_noop(Data, Flag) of
+        true ->
+            {ok, 0};
+        false ->
+            %% This is an sync send, set flag ?QUICER_SEND_FLAG_SYNC
+            case quicer_nif:send(Stream, Data, Flag bor ?QUICER_SEND_FLAG_SYNC) of
+                %% @todo make ref
+                {ok, _Len} = OK ->
+                    receive
+                        {quic, send_complete, Stream, false} ->
+                            OK;
+                        {quic, send_complete, Stream, true} ->
+                            {error, cancelled}
+                    end;
+                E ->
+                    E
+            end
     end.
+
+%% A zero-length send without FIN or START transmits nothing, and handing
+%% it to msquic can permanently wedge the stream send path when the stream
+%% has been switched from passive to active mode with a receive pending
+%% (see #441). Treat it as a no-op instead.
+is_zero_len_send_noop(Data, Flag) ->
+    (Flag band (?QUIC_SEND_FLAG_FIN bor ?QUIC_SEND_FLAG_START)) =:= 0 andalso
+        try iolist_size(Data) of
+            0 -> true;
+            _ -> false
+        catch
+            %% not iodata; let the NIF report badarg
+            _:_ -> false
+        end.
 
 %% @doc async variant of {@link send/3}
 %% If QUICER_SEND_FLAG_SYNC is set , the caller should expect to receive
@@ -801,7 +820,15 @@ send(Stream, Data, Flag) when is_integer(Flag) ->
     | {error, badarg | not_enough_mem | closed}
     | {error, stream_send_error, atom_reason()}.
 async_send(Stream, Data, Flag) ->
-    quicer_nif:send(Stream, Data, Flag).
+    case is_zero_len_send_noop(Data, Flag) of
+        true ->
+            %% preserve the completion contract for sync callers
+            (Flag band ?QUICER_SEND_FLAG_SYNC) =/= 0 andalso
+                (self() ! {quic, send_complete, Stream, false}),
+            {ok, 0};
+        false ->
+            quicer_nif:send(Stream, Data, Flag)
+    end.
 
 %% @doc async variant of {@link send/2}
 %% Caller should NOT expect to receive

--- a/test/quicer_SUITE.erl
+++ b/test/quicer_SUITE.erl
@@ -71,7 +71,8 @@
     tc_stream_passive_switch_to_active2/1,
     tc_stream_passive_switch_to_active_race/1,
     tc_stream_passive_switch_to_active_while_recv_pend/1,
-    %tc_stream_passive_switch_to_active_with_recv_pending/1,
+    tc_stream_passive_switch_to_active_with_recv_pending/1,
+    tc_stream_pend_switch_then_empty_send/1,
     tc_stream_passive_partial_recv_switch_to_active_n/1,
     tc_stream_passive_pending_switch_to_active_n/1,
     tc_stream_active_switch_to_passive/1,
@@ -761,6 +762,40 @@ tc_stream_passive_switch_to_active_with_recv_pending(Config) ->
     {ok, 13} = quicer:send(Stm, <<"ping_active_2">>),
     receive
         {quic, <<"ping_active_2">>, Stm, _} -> ok
+    end,
+    SPid ! done,
+    ensure_server_exit_normal(Ref).
+
+%% @doc A zero-length send must be a no-op: handing it to msquic after a
+%% pended passive receive was switched to active mode permanently wedged
+%% the stream send path (nothing sent afterwards reached the peer and the
+%% connection died of idle timeout). Deterministic root cause of the
+%% flakiness in tc_stream_passive_switch_to_active_with_recv_pending.
+tc_stream_pend_switch_then_empty_send(Config) ->
+    Port = select_port(),
+    Owner = self(),
+    {SPid, Ref} = spawn_monitor(fun() -> echo_server(Owner, Config, Port) end),
+    receive
+        listener_ready -> ok
+    after 6000 -> ct:fail("timeout")
+    end,
+    {ok, Conn} = quicer:connect("localhost", Port, default_conn_opts(), 5000),
+    {ok, Stm} = quicer:start_stream(Conn, [{active, false}]),
+    {ok, 15} = quicer:send(Stm, <<"ping_passiveeee">>),
+    %% let the echo arrive and pend in the passive recv callback
+    timer:sleep(100),
+    ok = quicer:setopt(Stm, active, true),
+    {ok, 0} = quicer:send(Stm, <<"">>),
+    %% the pended data is re-indicated and delivered
+    receive
+        {quic, <<"ping_passiveeee">>, Stm, _} -> ok
+    after 1000 -> ct:fail("pended data not delivered")
+    end,
+    %% data sent after the zero-length send must still reach the peer
+    {ok, 11} = quicer:send(Stm, <<"ping_active">>),
+    receive
+        {quic, <<"ping_active">>, Stm, _} -> ok
+    after 1000 -> ct:fail("send path wedged after zero-length send")
     end,
     SPid ! done,
     ensure_server_exit_normal(Ref).


### PR DESCRIPTION
A zero-length send handed to msquic can permanently wedge the stream send path: msquic sets `QUIC_STREAM_SEND_FLAG_DATA` for the empty request, the resulting flush has nothing to write and never clears the flag, and every later `StreamSend` skips queueing a flush because the flag is already set. Nothing sent afterwards reaches the peer and the connection eventually dies of idle timeout. Root cause with an instrumented trace and a standalone C repro is filed as microsoft/msquic#6243; full bisection story in #441 (comments).

This was the actual root cause of the flakiness in `tc_stream_passive_switch_to_active_with_recv_pending`: the empty send in that test wedges the stream whenever the connection is quiescent at that moment, which depends on timing. It was never a receive-path or reordering problem.

Changes:

- `quicer:send/3` and `quicer:async_send/3` treat a zero-length send without `FIN` or `START` as a no-op returning `{ok, 0}`. Nothing legitimate is transmitted for such a request anyway; empty sends carrying `FIN` (graceful shutdown) or `START` still go through. For async callers that pass `QUICER_SEND_FLAG_SYNC`, the `send_complete` message contract is preserved.
- Re-enables `tc_stream_passive_switch_to_active_with_recv_pending` (passes 5/5 with the guard, failed 30/30 without it on this machine).
- Adds `tc_stream_pend_switch_then_empty_send`, a deterministic regression test for the wedge.

Full `quicer_SUITE`: 110/110.
